### PR TITLE
Replace MSG91 Hello chat widget with chatbot.gtwy.ai

### DIFF
--- a/src/app/providers.js
+++ b/src/app/providers.js
@@ -107,21 +107,13 @@ export default function AppProvider({ children }) {
   }
 
   useEffect(() => {
-    const helloConfig = {
-      widgetToken: 'a13cc',
-      show_close_button: true,
-      hide_launcher: true,
-      urlsToOpenInIFrame: [
-        'https://viasocket.com/faq',
-        'https://viasocket.com/discovery',
-        'https://viasocket.com/blog',
-        'https://viasocket.com/community',
-      ],
-    };
-
     const script = document.createElement('script');
-    script.src = 'https://blacksea.msg91.com/chat-widget.js';
-    script.onload = () => initChatWidget(helloConfig, 50);
+    script.id = 'chatbot-main-script';
+    script.src = 'https://chatbot.gtwy.ai/chatbot.js';
+    script.setAttribute('embedToken', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiIxMjc3IiwiY2hhdGJvdF9pZCI6IjY2NTA2MjhhZDQ4ZTIwZTYxY2Y3MDFhMCIsInVzZXJfaWQiOiJ0ZXN0X3VzZXIifQ.pU9ms9HhiBUKhvJuBUDiue03F2lmFAqBuwd6FCSdvgI');
+    script.setAttribute('bridgeName', 'viasocket_chat');
+    script.setAttribute('threadId', 'test_thread_id');
+    script.async = true;
 
     document.head.appendChild(script);
 

--- a/src/components/chat-widget/chat-wdget.js
+++ b/src/components/chat-widget/chat-wdget.js
@@ -4,7 +4,7 @@ import { MessageSquare } from 'lucide-react';
 
 export default function ChatWidget() {
     const openChatWidget = () => {
-        window.chatWidget.open();
+        window.openChatbot?.();
     };
     return (
         <>

--- a/src/components/chat-widget/chat-widget.module.scss
+++ b/src/components/chat-widget/chat-widget.module.scss
@@ -1,5 +1,5 @@
 .chat_widget {
-    @apply fixed bottom-6 right-6;
+    @apply fixed bottom-4 right-6;
     // padding-right: 20px !important;
     // padding-left: 20px !important;
     z-index: 100;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -265,3 +265,13 @@
 .bg-section{
     background-color: var(--bg-section);
 }
+
+// chatbot widget overrides
+#interfaceEmbed {
+    display: none !important;
+}
+
+#iframe-parent-container {
+    width: 380px !important;
+    height: 92% !important;
+}


### PR DESCRIPTION
## Summary
- Replaces the old MSG91 Hello widget (`blacksea.msg91.com/chat-widget.js`) with the new AI-powered chatbot from `chatbot.gtwy.ai`
- Retains the existing black "Chat" button as the launcher — clicking it calls `window.openChatbot()`
- Hides the new widget's default launcher icon via CSS overrides
- Sets chatbot popup to 380px wide and 92% tall for better UX
- Adjusts Chat button position to `bottom-4 right-6`

## Test plan
- [ ] Click the Chat button and verify the new chatbot opens
- [ ] Verify the old MSG91 widget no longer loads
- [ ] Check button position doesn't overlap page content across key pages (home, pricing, integrations)
- [ ] Test on mobile view

🤖 Generated with [Claude Code](https://claude.com/claude-code)