### PR TITLE
Generate fresh chat thread ID on every page load

### DIFF
--- a/src/app/providers.js
+++ b/src/app/providers.js
@@ -107,11 +107,7 @@ export default function AppProvider({ children }) {
   }
 
   useEffect(() => {
-    let threadId = localStorage.getItem('viasocket_chat_thread_id');
-    if (!threadId) {
-      threadId = crypto.randomUUID();
-      localStorage.setItem('viasocket_chat_thread_id', threadId);
-    }
+    const threadId = crypto.randomUUID();
 
     const script = document.createElement('script');
     script.id = 'chatbot-main-script';


### PR DESCRIPTION
## Summary
- Removed localStorage persistence of `viasocket_chat_thread_id` in `src/app/providers.js`
- A new UUID is now generated via `crypto.randomUUID()` on every page load, so each visit starts a fresh chat thread

## Test plan
- [ ] Open the site, confirm the chat widget loads
- [ ] Refresh the page and confirm a new `threadId` is sent to the chatbot script
- [ ] Verify `viasocket_chat_thread_id` is no longer being read from / written to localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)