### PR TITLE
VSWEB-696: remove chat widget iframe size overrides

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -286,8 +286,3 @@
 #interfaceEmbed {
     display: none !important;
 }
-
-#iframe-parent-container {
-    width: 380px !important;
-    height: 92% !important;
-}


### PR DESCRIPTION
## Summary
- Remove `#iframe-parent-container` width/height `!important` overrides from `src/scss/global.scss` since they are not provided/required by the chat widget script.

## Test plan
- [ ] Open any page, launch chat widget, confirm it renders at the size provided by `chatbot.gtwy.ai` script
- [ ] Verify no layout regressions on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)