### PR TITLE
Update embed page copy

### DIFF
--- a/src/app/components/embed/EmbedImageSelector.js
+++ b/src/app/components/embed/EmbedImageSelector.js
@@ -4,26 +4,26 @@ const FEATURES = [
     {
         icon: Lock,
         iconBg: 'bg-emerald-50 text-emerald-600',
-        title: 'End-user auth inside your product',
-        desc: 'Users connect via OAuth without leaving your product. Secure, isolated, and seamless.',
+        title: 'Built-in app authentication',
+        desc: 'Let users securely connect their apps without leaving your platform.',
     },
     {
         icon: Box,
         iconBg: 'bg-indigo-50 text-indigo-600',
         title: 'Connect any app in minutes',
-        desc: 'Pre-built connectors and OAuth flows to thousands of apps.',
+        desc: 'Connect to thousands of apps using pre-built connectors and built-in authentication.',
     },
     {
         icon: FileText,
         iconBg: 'bg-amber-50 text-amber-600',
-        title: 'Designed to feel built-in',
-        desc: 'Match the embed to your brand identity. It renders natively inside your product.',
+        title: 'Make automation feel native',
+        desc: 'Embed automation directly into your product with a fully customizable experience.',
     },
     {
         icon: Zap,
         iconBg: 'bg-violet-50 text-violet-600',
-        title: 'Built-in observability',
-        desc: 'Per-action metrics, failure rates. See what\u2019s running, what\u2019s failing, and what to fix. No extra setup.',
+        title: 'Built-in monitoring',
+        desc: 'Track every action in one place. See what\u2019s working, what\u2019s failing, and what needs attention.',
     },
 ];
 
@@ -45,13 +45,11 @@ const EmbedImageSelector = () => {
                     <div className="bg-[#EFEAFE] p-8 md:px-12 md:py-20 flex flex-col gap-8 justify-between">
                         <div className="flex flex-col gap-4">
                             <h3 className="text-3xl md:text-4xl font-medium text-gray-900 leading-tight">
-                                Give your users the access to build Multi-step flows
+                                Enable your users to build multi-step workflows
                             </h3>
                             <p className="text-gray-600 text-base leading-relaxed">
-                                Embed the visual builder and let your users chain triggers, actions and conditions
-                                across 2,500+ apps.
-                                <br />
-                                No code, no support tickets, no waiting on your roadmap.
+                                Embed a visual automation builder that enables users to create multi-step workflows
+                                using triggers, actions, and conditions across 2,500+ apps.
                             </p>
                         </div>
 

--- a/src/app/components/embed/EmbedPricing.js
+++ b/src/app/components/embed/EmbedPricing.js
@@ -66,19 +66,7 @@ function PlanCard({ plan }) {
             <div className="flex flex-col gap-2">
                 <span className="text-xs tracking-widest text-gray-500">USAGE</span>
                 <ul className="flex flex-col gap-2">
-                    {plan.usage.map((item, i) => (
-                        <li key={i} className="flex items-center gap-2 text-sm text-gray-800">
-                            <Check size={16} className="text-green-600 shrink-0" strokeWidth={3} />
-                            {item}
-                        </li>
-                    ))}
-                </ul>
-            </div>
-
-            <div className="flex flex-col gap-2">
-                <span className="text-xs tracking-widest text-gray-500">SUPPORT</span>
-                <ul className="flex flex-col gap-2">
-                    {plan.support.map((item, i) => (
+                    {[...plan.usage, ...plan.support].map((item, i) => (
                         <li key={i} className="flex items-center gap-2 text-sm text-gray-800">
                             <Check size={16} className="text-green-600 shrink-0" strokeWidth={3} />
                             {item}
@@ -100,7 +88,7 @@ export default function EmbedPricing() {
             <div className="border border-gray-200 bg-white md:p-10 p-6 flex flex-col gap-8">
                 <div className="flex flex-col gap-1">
                     <h2 className="text-4xl font-medium text-black">Embed Pricing</h2>
-                    <p className="text-gray-600 text-lg">Simple, transparent pricing that grows with you.</p>
+                    <p className="text-gray-600 text-lg">Choose the perfect plan that fits your need.</p>
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/src/app/components/embed/EmbedSetupSteps.js
+++ b/src/app/components/embed/EmbedSetupSteps.js
@@ -63,10 +63,9 @@ export default function EmbedSetupSteps() {
         <div className="container">
             <div className="border bg-white p-8 md:p-12">
                 <h2 className="h2">Set up the embed in two steps</h2>
-                <p className="sub__h1 mt-2">
-                    Sign a JWT on your server, then drop a single script tag into your frontend.
-                    <br />
-                    No OAuth boilerplate, no webhook infrastructure to maintain.
+                <p className="sub__h1 mt-6">
+                    Generate a token, add a script, and you&apos;re ready to go. No OAuth flows or webhook
+                    infrastructure needed.
                 </p>
 
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">


### PR DESCRIPTION
## Summary
- Update copy on the embed page's "Everything you need to own the integration layer" section (left big card title/subtext + all four feature cards)
- Tighten the Embed Pricing card layout: merge usage and support lists so pointer spacing is even, remove the SUPPORT heading, and update the subtext to "Choose the perfect plan that fits your need."
- Update the "Set up the embed in two steps" subtext and increase spacing between the title and subtext

## Test plan
- [ ] Run `npm run dev` and visit `/embed`
- [ ] Confirm the four feature cards show the new titles and descriptions
- [ ] Confirm pricing cards show pointers with even spacing and no SUPPORT label
- [ ] Confirm the setup steps subtext reads correctly with proper spacing below the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)