### PR TITLE
feat(pricing): billing plans with free plan, updated prices and yearly toggle

### DIFF
--- a/src/app/components/pricing/PricingPlansClient.js
+++ b/src/app/components/pricing/PricingPlansClient.js
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Check, X } from 'lucide-react';
+
+const plans = [
+    {
+        name: 'FREE PLAN',
+        monthly: { price: '$0', period: '/month' },
+        annual: { price: '$0', period: '/year', savings: '' },
+        features: [
+            { text: '2,000 tasks/month', included: true },
+            { text: '500 AI credits included', included: true },
+            { text: '1,500+ app connections', included: true },
+            { text: 'All basic built-in tools', included: true },
+            { text: 'Advanced AI models', included: false },
+            { text: 'Team members', included: false },
+            { text: 'Community support', included: true },
+        ],
+        ctaLink: '/signup?utm_source=pricing/free',
+        highlight: false,
+        ctaLabel: 'Get started free',
+    },
+    {
+        name: 'BASIC PLAN',
+        monthly: { price: '$29', period: '/month' },
+        annual: { price: '$293', period: '/year', savings: 'Save $78 by switching to annual' },
+        features: [
+            { text: '5,000 tasks/month', included: true },
+            { text: '2,000 AI credits included', included: true },
+            { text: '1,500+ app connections', included: true },
+            { text: 'All basic built-in tools', included: true },
+            { text: 'Advanced AI models', included: false },
+            { text: 'Team members', included: false },
+            { text: 'Standard ticket support', included: true },
+        ],
+        ctaLink: '/signup?utm_source=pricing/basic',
+        highlight: false,
+    },
+    {
+        name: 'TEAM PLAN',
+        monthly: { price: '$59', period: '/month' },
+        annual: { price: '$593', period: '/year', savings: 'Save $158 by switching to annual' },
+        features: [
+            { text: '15,000 tasks/month', included: true },
+            { text: '5,000 AI credits included', included: true },
+            { text: 'Unlimited team members', included: true },
+            { text: 'All basic built-in tools', included: true },
+            { text: 'Advanced AI models', included: true },
+            { text: '5-min polling interval', included: true },
+            { text: 'Priority ticket support', included: true },
+        ],
+        ctaLink: '/signup?utm_source=pricing/team',
+        highlight: false,
+    },
+    {
+        name: 'ADVANCED PLAN',
+        monthly: { price: '$74', period: '/month' },
+        annual: { price: '$743', period: '/year', savings: 'Save $198 by switching to annual' },
+        features: [
+            { text: '25,000 tasks/month', included: true },
+            { text: '10,000 AI credits included', included: true },
+            { text: 'Unlimited team members', included: true },
+            { text: 'All basic built-in tools', included: true },
+            { text: 'Advanced AI models', included: true },
+            { text: '1-min polling (real-time)', included: true },
+            { text: 'Top priority queue', included: true },
+            { text: 'One on One live expert support', included: true },
+        ],
+        ctaLink: '/signup?utm_source=pricing/advanced',
+        highlight: false,
+    },
+];
+
+function PlanCard({ plan, isAnnual }) {
+    const pricing = isAnnual ? plan.annual : plan.monthly;
+
+    return (
+        <div className={`flex flex-col bg-white h-full ${plan.highlight ? 'border-2 border-accent' : 'border border-gray-200'}`}>
+            <div className="flex flex-col gap-5 p-6 md:p-8 flex-1" style={plan.highlight ? { paddingTop: '2.5rem' } : {}}>
+                <div className="flex flex-col gap-1">
+                    <span className="text-xs tracking-widest text-gray-500">{plan.name}</span>
+                    <div className="flex items-baseline gap-1">
+                        <span className="text-4xl font-bold text-black">{pricing.price}</span>
+                        <span className="text-sm text-gray-500">{pricing.period}</span>
+                    </div>
+                    {isAnnual && plan.annual.savings && (
+                        <span className="text-sm text-green-600 font-medium">{plan.annual.savings}</span>
+                    )}
+                </div>
+
+                <div className="border-t border-gray-200" />
+
+                <ul className="flex flex-col gap-3 flex-1">
+                    {plan.features.map((feature, i) => (
+                        <li key={i} className={`flex items-center gap-2 text-sm ${feature.included ? 'text-gray-800' : 'text-gray-400'}`}>
+                            {feature.included ? (
+                                <Check size={15} className="text-green-600 shrink-0" strokeWidth={3} />
+                            ) : (
+                                <X size={15} className="text-gray-300 shrink-0" strokeWidth={3} />
+                            )}
+                            <span className={feature.included ? '' : 'line-through'}>{feature.text}</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <Link
+                    href={plan.ctaLink}
+                    className={`w-full mt-auto text-center ${plan.highlight ? 'btn btn-accent' : 'btn btn-outline'}`}
+                >
+                    {plan.ctaLabel || 'Select Plan'}
+                </Link>
+            </div>
+        </div>
+    );
+}
+
+export default function PricingPlansClient() {
+    const [isAnnual, setIsAnnual] = useState(false);
+
+    return (
+        <div className="flex flex-col gap-8 w-full" id="pricingTabs">
+            <div className="flex items-center justify-center">
+                <div className="flex items-center bg-gray-100 p-1 border border-gray-200 rounded-full gap-1">
+                    <button
+                        onClick={() => setIsAnnual(false)}
+                        className={`px-5 py-2 text-sm rounded-full transition-all whitespace-nowrap ${!isAnnual ? 'bg-white shadow text-black font-semibold' : 'text-gray-500'}`}
+                    >
+                        Monthly
+                    </button>
+                    <button
+                        onClick={() => setIsAnnual(true)}
+                        className={`px-5 py-2 text-sm rounded-full transition-all whitespace-nowrap ${isAnnual ? 'bg-white shadow text-black font-semibold' : 'text-gray-500'}`}
+                    >
+                        Yearly <span className="text-green-600 font-semibold">(Save upto 17%)</span>
+                    </button>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-6 items-stretch">
+                {plans.map((plan) => (
+                    <PlanCard key={plan.name} plan={plan} isAnnual={isAnnual} />
+                ))}
+            </div>
+
+        </div>
+    );
+}

--- a/src/app/pricing/page.js
+++ b/src/app/pricing/page.js
@@ -4,10 +4,9 @@ import MetaHeadComp from '@/components/metaHeadComp/metaHeadComp';
 import NavbarServer from '../components/navbar/NavbarServer';
 import ConditionalNavbar from '@/components/ConditionalLayout/ConditionalNavbar';
 import ConditionalFooter from '@/components/ConditionalLayout/ConditionalFooter';
-import PricingTabsClient from '../components/pricing/PricingTabsClient';
+import PricingPlansClient from '../components/pricing/PricingPlansClient';
 import { getPricingPageData } from '../lib/pricing-data';
 import Link from 'next/link';
-import { Check } from 'lucide-react';
 import DashboardButton from '@/components/dashboardButton/dashboardButton';
 import { getHasToken } from '../lib/getAuth';
 
@@ -35,7 +34,7 @@ export async function generateMetadata() {
 }
 
 export default async function PricingPage() {
-    const { footerData, faqData, metaData, features, countries, appCount, navbarData } = await getPricingPageData();
+    const { footerData, faqData, metaData, navbarData } = await getPricingPageData();
     const hasToken = await getHasToken();
 
     return (
@@ -45,64 +44,17 @@ export default async function PricingPage() {
                 <NavbarServer navbarData={navbarData} utm={'/pricing'} />
             </ConditionalNavbar>
             <div className="container cont pb-4 pt-12 lg:gap-20 md:gap-16 gap-12 global-top-space">
-                <div className="cont flex flex-col items-center text-center gap-6">
-                    <div className="flex flex-col items-center">
-                        <h1 className="text-6xl">
-                            Start <span className="text-accent">free</span> and pay as you go
+                <div className="flex flex-col items-center gap-6 w-full max-w-6xl mx-auto">
+                    <div className="flex flex-col items-center text-center gap-2 pt-8">
+                        <h1 className="text-4xl font-bold">
+                            Choose the Plan That Fits <span className="text-accent">Your Needs</span>
                         </h1>
-                        <h2 className="text-2xl max-w-[650px]">
-                            Top up with{' '}
-                            <Link href="#pricingTabs" className="border-b-2 custom-border border-dotted">
-                                <span>credits</span>
-                            </Link>{' '}
-                            anytime. Use them for paid built-in plugs or extra tasks to keep your automations running.
-                        </h2>
+                        <p className="text-lg text-gray-500">
+                            Keep your automations running smoothly with flexible credits for plugins and extra usage.
+                        </p>
                     </div>
-                    <div className="cont lg:flex-row items-center gap-2 mt-4">
-                        <DashboardButton utm_src={"/pricing/hero"} hasToken={hasToken} />
-                        <Link
-                            href="https://cal.id/team/viasocket/workflow-setup-discussion"
-                            className="btn btn-outline"
-                            target="_blank"
-                        >
-                            Free call with automation experts
-                        </Link>
-                    </div>
+                    <PricingPlansClient />
                 </div>
-
-                <div className="flex items-center justify-center">
-                    <div className="gap-8 border custom-border p-6 md:p-12 bg-[#faf9f6] mt-4 max-w-[1000px]">
-                        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-[max-content_max-content_max-content] gap-4 gap-x-20">
-                            {features.map((feature, index) =>
-                                index === 0 ? (
-                                    <div key={index} className="flex items-center gap-2">
-                                        <Check className="w-4 h-4 text-accent" />
-                                        <p className="text-lg leading-tight">Connect to {+appCount + 300}+ apps</p>
-                                    </div>
-                                ) : (
-                                    <div key={index} className="flex items-center gap-2">
-                                        <Check className="w-4 h-4 text-accent" />
-                                        <p className="text-lg leading-tight">{feature.featurename}</p>
-                                    </div>
-                                )
-                            )}
-                            <div className="flex items-start gap-1">
-                                <p className="text-accent">+</p>
-                                <Link
-                                    href="/features"
-                                    target="_blank"
-                                    className="text-lg text-accent hover:underline w-fit"
-                                >
-                                    See all features
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* <div id="pricingTabs">
-                    <PricingTabsClient countries={countries} />
-                </div> */}
 
                 <div className="cont flex items-center justify-center w-full">
                     <div className="cont w-full flex flex-col items-center gap-8 justify-center bg-white border custom-border p-6 md:p-12 text-center access-program text-white">


### PR DESCRIPTION
## Summary
- Added Free plan card (2,000 tasks, 500 AI credits)
- Updated monthly prices: Basic $29, Team $59, Advanced $74
- Updated annual prices with correct savings amounts
- Monthly/Yearly toggle with "Save upto 17%" label
- 4-column card grid with max-w-6xl container
- Removed Start Free Plan CTA

## Test plan
- [ ] Visit `/pricing` and verify all 4 plan cards render correctly
- [ ] Toggle between Monthly and Yearly — prices and green savings text should update
- [ ] Verify Free plan shows $0 with correct features
- [ ] Check crossed-out features on Basic and Free plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)