### PR TITLE
Lifetime deal page updates

### DIFF
--- a/src/app/lifetime-deal/Comparison.js
+++ b/src/app/lifetime-deal/Comparison.js
@@ -31,7 +31,7 @@ export default function Comparison() {
                     Comparable automation platforms require ongoing annual subscriptions.
                 </p>
 
-                <div className="grid grid-cols-1 lg:grid-cols-[310px_1fr] gap-6 items-stretch max-w-[540px] lg:max-w-none mx-auto">
+                <div className="grid grid-cols-1 lg:grid-cols-[40%_60%] gap-6 items-stretch max-w-[540px] lg:max-w-none mx-auto">
                     {/* Left dark card */}
                     <div className="bg-[#111] rounded-[22px] border border-white/10 p-7 pb-6 flex flex-col group transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_20px_50px_-12px_rgba(0,0,0,0.5)] hover:border-white/20">
                         <div className="flex items-center gap-2.5 mb-7">

--- a/src/app/lifetime-deal/Comparison.js
+++ b/src/app/lifetime-deal/Comparison.js
@@ -24,11 +24,12 @@ export default function Comparison() {
                 <span className="block text-center text-[11px] font-bold tracking-[0.2em] uppercase text-accent mb-[22px]">
                     THE MATH IS THE PITCH
                 </span>
-                <h2 className="text-3xl sm:text-5xl lg:text-[58px] font-extrabold tracking-[-2px] leading-[1.06] text-center mb-16">
-                    Automation should scale your work.
-                    <br />
-                    Not your <span className="text-accent">bills.</span>
+                <h2 className="text-3xl sm:text-5xl lg:text-[58px] font-extrabold tracking-[-2px] leading-[1.06] text-center mb-4">
+                    Why keep paying every year?
                 </h2>
+                <p className="text-center text-gray-500 text-lg mb-16">
+                    Comparable automation platforms require ongoing annual subscriptions.
+                </p>
 
                 <div className="grid grid-cols-1 lg:grid-cols-[310px_1fr] gap-6 items-stretch max-w-[540px] lg:max-w-none mx-auto">
                     {/* Left dark card */}
@@ -95,7 +96,7 @@ export default function Comparison() {
                                     <div className="h-px bg-black/5 mt-4 mb-3.5" />
                                     <span className="text-[26px] font-extrabold tracking-[-0.8px] block">{c.price}</span>
                                     <div className="mt-1 text-[11px] font-semibold tracking-wider uppercase text-gray-500">
-                                        3-year cost
+                                        {c.priceLabel || '3-year cost'}
                                     </div>
                                 </div>
                             ))}

--- a/src/app/lifetime-deal/Faq.js
+++ b/src/app/lifetime-deal/Faq.js
@@ -4,64 +4,20 @@ import { useState } from 'react';
 
 const FAQS = [
     {
-        q: 'Is this really a one-time payment?',
-        a: <p>Yes. $250 once. No monthly bill, no annual renewal, no auto-charges.</p>,
+        q: 'Is this a one-time purchase?',
+        a: <p>Yes. One-time payment. No monthly bill, no annual renewal, no auto-charges.</p>,
     },
     {
-        q: 'What counts as a “task”?',
-        a: (
-            <p>
-                A task is one action step in a workflow when it executes successfully. Triggers and internal logic steps
-                (conditions, formatters, filters) don’t count against your task limit.
-            </p>
-        ),
-    },
-    {
-        q: 'Can I buy multiple lifetime licenses?',
+        q: 'Can I purchase more than one lifetime license?',
         a: <p>One lifetime license per customer during this offer. Each license is tied to a single account.</p>,
     },
     {
-        q: 'What counts as an “AI credit”?',
-        a: (
-            <p>
-                One AI credit is one AI action call — summarizing, classifying, generating, or extracting content using
-                our built-in models.
-            </p>
-        ),
-    },
-    {
-        q: 'Refunds?',
+        q: 'Do you offer refunds?',
         a: <p>Full refund within 30 days, no questions asked. After 30 days the purchase is final.</p>,
     },
     {
-        q: 'What if I exceed 15,000 tasks or 5,000 credits?',
-        a: <p>Add extra tasks or credits anytime, at standard rates. Your lifetime access doesn’t change.</p>,
-    },
-    {
-        q: 'Is this offer coming back?',
-        a: <p>This is a one-time launch offer for early adopters. We have no plans to repeat it at this price point.</p>,
-    },
-    {
-        q: 'Will I get future features?',
-        a: (
-            <p>
-                Yes. All future updates to the Team plan are included — new triggers, integrations, AI models, and
-                workflow tools.
-            </p>
-        ),
-    },
-    {
-        q: 'Can I upgrade to Premium later?',
-        a: <p>Yes. You can move to a Premium plan anytime — your lifetime credit applies toward the difference.</p>,
-    },
-    {
-        q: 'What if viaSocket shuts down?',
-        a: (
-            <p>
-                “Lifetime” means for as long as viaSocket operates. We’re profitable, growing, and built for the long
-                term — but we want to be honest about what lifetime can promise.
-            </p>
-        ),
+        q: 'What happens if I exceed my task or credit limits?',
+        a: <p>Add extra tasks or credits anytime, at standard rates. Your lifetime access doesn't change.</p>,
     },
 ];
 

--- a/src/app/lifetime-deal/Integrations.js
+++ b/src/app/lifetime-deal/Integrations.js
@@ -23,7 +23,7 @@ export default function Integrations() {
             <div aria-hidden className="absolute inset-0 pointer-events-none [background-image:linear-gradient(rgba(255,255,255,0.028)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.028)_1px,transparent_1px)] [background-size:52px_52px] [mask-image:radial-gradient(ellipse_85%_85%_at_50%_50%,black_10%,transparent_100%)]" />
             <div aria-hidden className="absolute inset-0 pointer-events-none [background:radial-gradient(ellipse_55%_45%_at_50%_60%,rgba(168,32,13,0.22)_0%,transparent_70%)]" />
             <div className="relative z-10 px-5 lg:px-20 container mx-auto">
-                <div className="inline-block text-accent text-[11px] font-bold tracking-[0.17em] uppercase mb-[22px]">2,200+ APP INTEGRATIONS</div>
+                <div className="inline-block text-[11px] font-bold tracking-[0.17em] uppercase mb-[22px]" style={{ color: '#E45656' }}>2,200+ APP INTEGRATIONS</div>
                 <h2 className="text-3xl sm:text-5xl lg:text-[54px] font-extrabold leading-[1.08] tracking-[-1.4px] mb-5 text-white">
                     One Platform. Endless Connections.<br />
                     Power Every Workflow with viaSocket.

--- a/src/app/lifetime-deal/Pricing.js
+++ b/src/app/lifetime-deal/Pricing.js
@@ -1,80 +1,40 @@
-import { Check as CheckIcon, X, ArrowUpRight } from 'lucide-react';
+import { Check as CheckIcon, X } from 'lucide-react';
 
-const Check = () => (
-    <span
-        className="w-5 h-5 rounded-full border-[1.4px] border-accent flex items-center justify-center shrink-0"
-        aria-hidden
-    >
-        <CheckIcon size={10} strokeWidth={2.2} className="text-[#A8200D]" />
-    </span>
-);
-const Cross = () => (
-    <span
-        className="w-5 h-5 rounded-full border-[1.4px] border-gray-500 flex items-center justify-center shrink-0"
-        aria-hidden
-    >
-        <X size={10} strokeWidth={2} className="text-[#6b7280]" />
-    </span>
-);
-const Arrow = () => (
-    <ArrowUpRight
-        size={14}
-        strokeWidth={2}
-        className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-        aria-hidden
-    />
-);
+const Check = () => <CheckIcon size={15} strokeWidth={2.5} className="text-green-500 shrink-0" aria-hidden />;
+const Cross = () => <X size={14} strokeWidth={2} className="text-gray-300 shrink-0" aria-hidden />;
 
 function Card({ eyebrow, oldPrice, price, features, support, cta, featured = false }) {
     return (
-        <article
-            className={`relative bg-white rounded-[20px] p-7 flex flex-col transition-all duration-300 hover:-translate-y-1 ${featured ? 'border-[1.5px] border-accent/20 shadow-[0_8px_28px_-8px_rgba(168,32,13,0.10),0_24px_56px_-16px_rgba(168,32,13,0.10)]' : 'border border-black/5 shadow-[0_1px_2px_rgba(0,0,0,0.02),0_6px_20px_-6px_rgba(0,0,0,0.06)] hover:shadow-[0_16px_40px_-10px_rgba(0,0,0,0.10)]'}`}
-        >
-            {featured && (
-                <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 z-10 inline-flex items-center gap-1.5 px-3 py-1 bg-accent text-white rounded-full text-[10px] font-bold tracking-[0.1em] uppercase whitespace-nowrap shadow-[0_2px_6px_rgba(168,32,13,0.32)]">
-                    <svg viewBox="0 0 12 12" className="w-2.5 h-2.5 fill-white/90" aria-hidden>
-                        <path d="M6 1l1.18 2.39 2.64.38-1.91 1.86.45 2.63L6 7.05l-2.36 1.21.45-2.63L2.18 3.77l2.64-.38z" />
-                    </svg>
-                    Most Popular
-                </div>
-            )}
-            <span className="block text-[11.5px] font-bold tracking-[0.16em] uppercase text-gray-500 mb-4">
+        <article className="relative bg-white rounded-2xl border border-gray-200 p-6 flex flex-col">
+            <span className="block text-xs font-bold tracking-widest uppercase text-gray-400 mb-1">
                 {eyebrow}
             </span>
             <div className="mb-4">
-                <div className="flex items-baseline gap-2 mb-1">
-                    <span className="text-lg text-gray-500 line-through font-medium">{oldPrice}</span>
-                    <span className="text-[44px] font-extrabold tracking-[-1.6px] leading-none">{price}</span>
+                <div className="flex items-baseline gap-1">
+                    <span className="text-4xl font-bold text-black">{price}</span>
+                    <span className="text-sm text-gray-400 line-through ml-2">{oldPrice}</span>
                 </div>
-                <div className="flex items-center gap-2 mt-1">
-                    <span className="text-[12.5px] text-accent font-medium">one-time payment</span>
-                </div>
+                <span className="text-xs text-accent font-medium">one-time payment</span>
             </div>
-            <div className="h-px bg-black/5 my-4" />
-            <ul className="list-none p-0 m-0 flex flex-col gap-[11px]">
+            <div className="h-px bg-gray-100 mb-4" />
+            <ul className="flex flex-col gap-3 flex-1">
                 {features.map((f, i) => (
-                    <li
-                        key={i}
-                        className={`flex items-center gap-2.5 text-[13.5px] leading-[1.4] ${f.excluded ? 'text-gray-500' : ''}`}
-                    >
+                    <li key={i} className={`flex items-center gap-2 text-sm ${f.excluded ? 'text-gray-300' : 'text-gray-700'}`}>
                         {f.excluded ? <Cross /> : <Check />}
                         <span className={f.excluded ? 'line-through' : ''}>{f.label}</span>
                     </li>
                 ))}
+                <li className="flex items-center gap-2 text-sm text-gray-700">
+                    <Check />
+                    <span>{support}</span>
+                </li>
             </ul>
-            <div className="h-px bg-black/5 my-4" />
-            <div className="mb-[18px]">
-                <div className="text-[10px] font-bold tracking-[0.16em] uppercase text-gray-400 mb-2.5">SUPPORT</div>
-                <ul className="list-none p-0 m-0 flex flex-col gap-[11px]">
-                    <li className="flex items-center gap-2.5 text-[13.5px]">
-                        <Check />
-                        <span>{support}</span>
-                    </li>
-                </ul>
-            </div>
-            <button type="button" aria-label={cta} className={`btn w-full ${featured ? 'btn-accent' : 'btn-outline'}`}>
-                <span>{cta}</span>
-                <Arrow />
+            <button
+                type="button"
+                aria-label={cta}
+                className="mt-6 w-full py-3 px-4 rounded-full border border-gray-300 text-sm font-bold text-black bg-white hover:bg-gray-50 transition-colors"
+            >
+                {cta}
             </button>
         </article>
     );

--- a/src/app/lifetime-deal/Pricing.js
+++ b/src/app/lifetime-deal/Pricing.js
@@ -1,41 +1,75 @@
-import { Check as CheckIcon, X } from 'lucide-react';
+import { Check as CheckIcon, X, ArrowUpRight } from 'lucide-react';
 
-const Check = () => <CheckIcon size={15} strokeWidth={2.5} className="text-green-500 shrink-0" aria-hidden />;
-const Cross = () => <X size={14} strokeWidth={2} className="text-gray-300 shrink-0" aria-hidden />;
+const Check = () => (
+    <span
+        className="w-5 h-5 rounded-full border-[1.4px] border-accent flex items-center justify-center shrink-0"
+        aria-hidden
+    >
+        <CheckIcon size={10} strokeWidth={2.2} className="text-[#A8200D]" />
+    </span>
+);
+const Cross = () => (
+    <span
+        className="w-5 h-5 rounded-full border-[1.4px] border-gray-500 flex items-center justify-center shrink-0"
+        aria-hidden
+    >
+        <X size={10} strokeWidth={2} className="text-[#6b7280]" />
+    </span>
+);
+const Arrow = () => (
+    <ArrowUpRight
+        size={14}
+        strokeWidth={2}
+        className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+        aria-hidden
+    />
+);
 
-function Card({ eyebrow, oldPrice, price, savings, features, support, cta, featured = false }) {
+function Card({ eyebrow, oldPrice, price, features, support, cta, featured = false }) {
     return (
-        <article className="relative bg-white rounded-2xl border border-gray-200 p-6 flex flex-col">
-            <span className="block text-xs font-bold tracking-widest uppercase text-gray-400 mb-1">
+        <article
+            className={`relative bg-white rounded-[20px] p-7 flex flex-col transition-all duration-300 hover:-translate-y-1 ${featured ? 'border-[1.5px] border-accent/20 shadow-[0_8px_28px_-8px_rgba(168,32,13,0.10),0_24px_56px_-16px_rgba(168,32,13,0.10)]' : 'border border-black/5 shadow-[0_1px_2px_rgba(0,0,0,0.02),0_6px_20px_-6px_rgba(0,0,0,0.06)] hover:shadow-[0_16px_40px_-10px_rgba(0,0,0,0.10)]'}`}
+        >
+            {featured && (
+                <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 z-10 inline-flex items-center gap-1.5 px-3 py-1 bg-accent text-white rounded-full text-[10px] font-bold tracking-[0.1em] uppercase whitespace-nowrap shadow-[0_2px_6px_rgba(168,32,13,0.32)]">
+                    <svg viewBox="0 0 12 12" className="w-2.5 h-2.5 fill-white/90" aria-hidden>
+                        <path d="M6 1l1.18 2.39 2.64.38-1.91 1.86.45 2.63L6 7.05l-2.36 1.21.45-2.63L2.18 3.77l2.64-.38z" />
+                    </svg>
+                    Most Popular
+                </div>
+            )}
+            <span className="block text-[11.5px] font-bold tracking-[0.16em] uppercase text-gray-500 mb-4">
                 {eyebrow}
             </span>
             <div className="mb-4">
-                <div className="flex items-baseline gap-1">
-                    <span className="text-4xl font-bold text-black">{price}</span>
+                <div className="flex items-baseline gap-2 mb-1">
+                    <span className="text-lg text-gray-500 line-through font-medium">{oldPrice}</span>
+                    <span className="text-[44px] font-extrabold tracking-[-1.6px] leading-none">{price}</span>
                 </div>
-                {savings && (
-                    <div className="text-xs text-green-600 font-medium mt-0.5">You save {savings}</div>
-                )}
             </div>
-            <div className="h-px bg-gray-100 mb-4" />
-            <ul className="flex flex-col gap-3 flex-1">
+            <div className="h-px bg-black/5 my-4" />
+            <ul className="list-none p-0 m-0 flex flex-col gap-[11px]">
                 {features.map((f, i) => (
-                    <li key={i} className={`flex items-center gap-2 text-sm ${f.excluded ? 'text-gray-300' : 'text-gray-700'}`}>
+                    <li
+                        key={i}
+                        className={`flex items-center gap-2.5 text-[13.5px] leading-[1.4] ${f.excluded ? 'text-gray-500' : ''}`}
+                    >
                         {f.excluded ? <Cross /> : <Check />}
                         <span className={f.excluded ? 'line-through' : ''}>{f.label}</span>
                     </li>
                 ))}
-                <li className="flex items-center gap-2 text-sm text-gray-700">
-                    <Check />
-                    <span>{support}</span>
-                </li>
             </ul>
-            <button
-                type="button"
-                aria-label={cta}
-                className="mt-6 w-full py-3 px-4 rounded-full border border-gray-300 text-sm font-bold text-black bg-white hover:bg-gray-50 transition-colors"
-            >
-                {cta}
+            <div className="mb-8 mt-4">
+                <ul className="list-none p-0 m-0 flex flex-col gap-[11px]">
+                    <li className="flex items-center gap-2.5 text-[13.5px]">
+                        <Check />
+                        <span>{support}</span>
+                    </li>
+                </ul>
+            </div>
+            <button type="button" aria-label={cta} className={`btn w-full ${featured ? 'btn-accent' : 'btn-outline'}`}>
+                <span>{cta}</span>
+                <Arrow />
             </button>
         </article>
     );
@@ -59,7 +93,6 @@ export default function Pricing() {
                         eyebrow="BASIC PLAN"
                         oldPrice="$599"
                         price="$390"
-                        savings="$209"
                         cta="Get Basic Plan"
                         features={[
                             { label: '5,000 tasks/month' },
@@ -75,7 +108,6 @@ export default function Pricing() {
                         eyebrow="TEAM PLAN"
                         oldPrice="$1,099"
                         price="$790"
-                        savings="$309"
                         cta="Get Team Plan"
                         featured
                         features={[
@@ -110,7 +142,6 @@ export default function Pricing() {
                         eyebrow="ADVANCED PLAN"
                         oldPrice="$1,399"
                         price="$990"
-                        savings="$409"
                         cta="Get Advanced Plan"
                         features={[
                             {

--- a/src/app/lifetime-deal/Pricing.js
+++ b/src/app/lifetime-deal/Pricing.js
@@ -12,9 +12,7 @@ function Card({ eyebrow, oldPrice, price, savings, features, support, cta, featu
             <div className="mb-4">
                 <div className="flex items-baseline gap-1">
                     <span className="text-4xl font-bold text-black">{price}</span>
-                    <span className="text-sm text-gray-400 line-through ml-2">{oldPrice}</span>
                 </div>
-                <span className="text-xs text-accent font-medium">one-time payment</span>
                 {savings && (
                     <div className="text-xs text-green-600 font-medium mt-0.5">You save {savings}</div>
                 )}

--- a/src/app/lifetime-deal/Pricing.js
+++ b/src/app/lifetime-deal/Pricing.js
@@ -3,7 +3,7 @@ import { Check as CheckIcon, X } from 'lucide-react';
 const Check = () => <CheckIcon size={15} strokeWidth={2.5} className="text-green-500 shrink-0" aria-hidden />;
 const Cross = () => <X size={14} strokeWidth={2} className="text-gray-300 shrink-0" aria-hidden />;
 
-function Card({ eyebrow, oldPrice, price, features, support, cta, featured = false }) {
+function Card({ eyebrow, oldPrice, price, savings, features, support, cta, featured = false }) {
     return (
         <article className="relative bg-white rounded-2xl border border-gray-200 p-6 flex flex-col">
             <span className="block text-xs font-bold tracking-widest uppercase text-gray-400 mb-1">
@@ -15,6 +15,9 @@ function Card({ eyebrow, oldPrice, price, features, support, cta, featured = fal
                     <span className="text-sm text-gray-400 line-through ml-2">{oldPrice}</span>
                 </div>
                 <span className="text-xs text-accent font-medium">one-time payment</span>
+                {savings && (
+                    <div className="text-xs text-green-600 font-medium mt-0.5">You save {savings}</div>
+                )}
             </div>
             <div className="h-px bg-gray-100 mb-4" />
             <ul className="flex flex-col gap-3 flex-1">
@@ -55,10 +58,11 @@ export default function Pricing() {
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <Card
-                        eyebrow="SOLO PLAN"
+                        eyebrow="BASIC PLAN"
                         oldPrice="$599"
                         price="$390"
-                        cta="Get Solo Plan"
+                        savings="$209"
+                        cta="Get Basic Plan"
                         features={[
                             { label: '5,000 tasks/month' },
                             { label: '2,000 AI credits' },
@@ -73,6 +77,7 @@ export default function Pricing() {
                         eyebrow="TEAM PLAN"
                         oldPrice="$1,099"
                         price="$790"
+                        savings="$309"
                         cta="Get Team Plan"
                         featured
                         features={[
@@ -104,10 +109,11 @@ export default function Pricing() {
                         support="Priority ticket support"
                     />
                     <Card
-                        eyebrow="PREMIUM PLAN"
+                        eyebrow="ADVANCED PLAN"
                         oldPrice="$1,399"
                         price="$990"
-                        cta="Get Premium Plan"
+                        savings="$409"
+                        cta="Get Advanced Plan"
                         features={[
                             {
                                 label: (


### PR DESCRIPTION
## Summary
- Changed "2,200+ APP INTEGRATIONS" label color to `#E45656` in Integrations section
- Trimmed FAQ to 4 questions (one-time purchase, multiple licenses, refunds, exceeding limits)
- Updated Comparison section heading to "Why keep paying every year?" with new subtext
- Redesigned Pricing cards: rounded corners, pill-shaped CTAs, inline strikethrough old prices, green checkmarks

## Test plan
- [ ] Visit `/lifetime-deal#integrations` — confirm label is orange-red (#E45656)
- [ ] Visit `/lifetime-deal#faq` — confirm only 4 FAQs are shown, no smart quote errors
- [ ] Visit `/lifetime-deal#comparison` — confirm updated heading and subtext
- [ ] Visit `/lifetime-deal#pricing` — confirm card redesign: rounded cards, green checks, gray × strikethrough, pill CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)