### PR TITLE
update lifetime deal pricing: change Advanced to Premium, update pric…

### DIFF
--- a/src/app/lifetime-deal/Hero.js
+++ b/src/app/lifetime-deal/Hero.js
@@ -20,7 +20,7 @@ export default function Hero() {
                     className="absolute inset-0 pointer-events-none [background:radial-gradient(ellipse_40%_35%_at_50%_30%,rgba(168,32,13,0.10),transparent_70%)]"
                 />
 
-                <div className="relative z-10 container mx-auto px-8 flex-1 grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] py-10 lg:py-2 gap-16 items-center">
+                <div className="relative z-10 container mx-auto px-8 flex-1 grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] py-20 lg:py-2 gap-16 items-center">
                     <HeroContent />
                     <PricingCard />
                 </div>

--- a/src/app/lifetime-deal/HeroContent.js
+++ b/src/app/lifetime-deal/HeroContent.js
@@ -41,7 +41,7 @@ export default function HeroContent() {
             <div className="flex items-center gap-6 flex-wrap mb-8">
                 <Link href="#pricing" className="btn btn-accent" rel="nofollow noopener noreferrer">
                     <span>Get Lifetime Access</span>
-                    <span className="hidden sm:inline text-[13px] font-semibold opacity-90">from $399</span>
+                    <span className="hidden sm:inline text-[13px] font-semibold opacity-90">from $390</span>
                     <span aria-hidden className="text-lg leading-none">
                         &rarr;
                     </span>

--- a/src/app/lifetime-deal/HowItWorks.js
+++ b/src/app/lifetime-deal/HowItWorks.js
@@ -39,7 +39,7 @@ export default function HowItWorks() {
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-8 lg:gap-10">
                     {STEPS.map((s) => (
                         <div key={s.num} className="flex flex-col items-center text-center justify-between">
-                            <div className="w-full relative aspect-[16/10]">
+                            <div className="w-full relative aspect-[16/8]">
                                 <Image
                                     src={s.image}
                                     alt={s.title}

--- a/src/app/lifetime-deal/Pricing.js
+++ b/src/app/lifetime-deal/Pricing.js
@@ -25,7 +25,7 @@ const Arrow = () => (
     />
 );
 
-function Card({ eyebrow, oldPrice, price, features, support, cta, featured = false }) {
+function Card({ eyebrow, oldPrice, price, features, support, cta, href, featured = false }) {
     return (
         <article
             className={`relative bg-white rounded-[20px] p-7 flex flex-col transition-all duration-300 hover:-translate-y-1 ${featured ? 'border-[1.5px] border-accent/20 shadow-[0_8px_28px_-8px_rgba(168,32,13,0.10),0_24px_56px_-16px_rgba(168,32,13,0.10)]' : 'border border-black/5 shadow-[0_1px_2px_rgba(0,0,0,0.02),0_6px_20px_-6px_rgba(0,0,0,0.06)] hover:shadow-[0_16px_40px_-10px_rgba(0,0,0,0.10)]'}`}
@@ -67,10 +67,16 @@ function Card({ eyebrow, oldPrice, price, features, support, cta, featured = fal
                     </li>
                 </ul>
             </div>
-            <button type="button" aria-label={cta} className={`btn w-full ${featured ? 'btn-accent' : 'btn-outline'}`}>
+            <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={cta}
+                className={`btn w-full ${featured ? 'btn-accent' : 'btn-outline'}`}
+            >
                 <span>{cta}</span>
                 <Arrow />
-            </button>
+            </a>
         </article>
     );
 }
@@ -103,6 +109,7 @@ export default function Pricing() {
                             { label: '15-min polling interval' },
                         ]}
                         support="Standard ticket support"
+                        href="https://buy.stripe.com/14AfZhad66qD6JjfM72go12"
                     />
                     <Card
                         eyebrow="TEAM PLAN"
@@ -137,12 +144,13 @@ export default function Pricing() {
                             { label: '5-min polling interval' },
                         ]}
                         support="Priority ticket support"
+                        href="https://buy.stripe.com/fZuaEXfxqg1daZz8jF2go13"
                     />
                     <Card
-                        eyebrow="ADVANCED PLAN"
+                        eyebrow="PREMIUM PLAN"
                         oldPrice="$1,399"
                         price="$990"
-                        cta="Get Advanced Plan"
+                        cta="Get Premium Plan"
                         features={[
                             {
                                 label: (
@@ -170,6 +178,7 @@ export default function Pricing() {
                             { label: '1-min polling (real-time)' },
                         ]}
                         support="1-on-1 live expert support"
+                        href="https://buy.stripe.com/cNi14n992dT55Ff6bx2go14"
                     />
                 </div>
 


### PR DESCRIPTION
…es and CTAs, adjust hero spacing and step card aspect ratio

- Pricing: rename Advanced Plan to Premium Plan, update CTA text
- Hero: increase mobile py from 10 to 20
- HeroContent: update starting price from $399 to $390
- HowItWorks: change step card aspect ratio from 16/10 to 16/8
- Pricing cards: convert CTA buttons to links with Stripe checkout URLs, add target="_blank" and rel attributes || 1