### PR TITLE
Agency partner page UI updates

### DIFF
--- a/src/app/components/home/ShowAppsIndexOptimized.js
+++ b/src/app/components/home/ShowAppsIndexOptimized.js
@@ -148,7 +148,7 @@ export default function ShowAppsIndexOptimized({
     return (
         <div className="flex flex-col gap-6">
             {isHomePage || isTrustMarquee ? (
-                <div className={`flex flex-col items-center justify-center ${isHomePage ? 'gap-2 my-12' : 'gap-8 my-8'}`}>
+                <div className={`flex flex-col items-center justify-center ${isHomePage ? 'gap-2 my-12' : 'gap-8 mb-8 mt-2'}`}>
                     {appCount ? (
                         <p className="text-center text-[13px] font-semibold tracking-[0.1em] text-[#999] uppercase">
                             <strong className="text-[#555] font-medium">{appCount + 300}+</strong> applications integrated

--- a/src/components/agencyPartner/AgencyPricing.js
+++ b/src/components/agencyPartner/AgencyPricing.js
@@ -1,109 +1,102 @@
 import Link from 'next/link';
 
+const stats = [
+    { value: '250K', label: 'tasks per month, shared across all client workspaces' },
+    { value: '100%', label: 'of revenue retained. No commissions, no splits.' },
+    { value: '100K', label: 'AI credits included per month.' },
+];
+
+const includedItems = [
+    'Unlimited workspace creation',
+    '250,000 tasks / month',
+    '100,000 AI credits included',
+    'All premium features included',
+    '1-on-1 live support',
+    '$0.00021 per task overage',
+];
+
 const AgencyPricing = () => {
-    const featuresLeft = [
-        'No revenue sharing. Keep 100% of what you charge.',
-        'One shared task pool across all client workspaces.',
-        '$0.00021 per task beyond your monthly limit.',
-        'Includes 1-on-1 live support.',
-    ];
-
-    const includedItems = [
-        'Unlimited Workspace Creation',
-        '250,000 tasks / month',
-        '100,000 AI credits included',
-        'All basic built-in tools',
-        'Advanced AI models',
-        '1-min polling',
-    ];
-
     return (
-        <section id="pricing" className="max-w-6xl mx-auto px-4 py-20">
-            <div className="flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-20">
+        <section id="pricing" className="w-full bg-white py-20">
+            <div className="max-w-6xl mx-auto px-4">
+            <div className="flex flex-col lg:flex-row items-center justify-center gap-8 lg:gap-12">
                 {/* Left Content */}
-                <div className="flex-1 max-w-xl">
-                    <h2 className="h2 mb-4">
+                <div className="flex-1 max-w-lg">
+                    <h2 className="h2 mb-5" style={{fontWeight: 900}}>
                         One plan.
                         <br />
                         Everything included.
                     </h2>
-                    <p className="text-gray-600 text-base mb-8 max-w-md">
-                        No per-seat fees, no per-workspace charges, no surprises. One flat rate that scales with your
-                        task usage.
+                    <p className="text-gray-600 text-base mb-10 max-w-md leading-relaxed">
+                        No per-seat fees, no workspace charges, no revenue splits.
+                        One flat rate for your whole practice.
                     </p>
 
-                    <ul className="space-y-4">
-                        {featuresLeft.map((feature, index) => (
-                            <li key={index} className="flex items-start gap-3">
-                                <svg
-                                    className="w-5 h-5 text-[#A8200D] mt-0.5 flex-shrink-0"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M5 13l4 4L19 7"
-                                    />
-                                </svg>
-                                <span className="text-gray-700 text-sm">{feature}</span>
-                            </li>
+                    <div className="divide-y divide-gray-200 border-t border-gray-200">
+                        {stats.map((stat, i) => (
+                            <div key={i} className="flex items-center gap-6 py-5">
+                                <span className="text-[42px] font-bold text-gray-300 leading-none w-28 shrink-0">
+                                    {stat.value}
+                                </span>
+                                <span className="text-sm text-gray-500 leading-snug">{stat.label}</span>
+                            </div>
                         ))}
-                    </ul>
+                    </div>
                 </div>
 
                 {/* Right Card */}
-                <div className="w-full lg:w-[420px] flex-shrink-0">
-                    <div className="relative bg-[#fafafa] rounded-2xl p-6 pt-8 border border-gray-200">
+                <div className="w-full lg:w-[440px] flex-shrink-0">
+                    <div className="relative">
                         {/* Badge */}
-                        <span className="absolute -top-3 left-6 inline-block text-xs font-semibold text-gray-700 bg-white border border-gray-200 rounded-full px-3 py-1">
+                        <span className="absolute -top-4 left-6 z-10 inline-block text-xs font-semibold text-white bg-[#111] rounded-full px-4 py-1.5">
                             25% partner discount
                         </span>
 
-                        {/* Plan Name */}
-                        <p className="text-[11px] font-bold tracking-[0.15em] text-[#A8200D] uppercase mb-2">
-                            Agency Partner Plan
-                        </p>
-
-                        {/* Pricing */}
-                        <div className="mb-1">
-                            <span className="text-gray-400 text-base line-through">$350</span>
-                        </div>
-                        <div className="flex items-baseline gap-1 mb-1">
-                            <span className="text-5xl font-bold text-gray-900">$250</span>
-                            <span className="text-gray-500 text-base">/month</span>
-                        </div>
-                        <p className="text-gray-500 text-xs mb-6">Billed monthly. Cancel anytime.</p>
-
-                        {/* CTA Button */}
-                        <Link
-                            href="https://buy.stripe.com/aFafZhgBudT51oZbvR2go15"
-                            className="btn btn-accent mb-8 w-full"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Become a Partner
-                        </Link>
-
-                        {/* Divider */}
-                        <div className="border-t border-gray-200 pt-6">
-                            <p className="text-[10px] font-bold tracking-[0.15em] text-gray-400 uppercase mb-4">
-                                What&apos;s Included
+                        <div className="bg-[#FAF9F6] rounded-2xl p-5 pt-7">
+                            {/* Plan Name */}
+                            <p className="text-[11px] font-bold tracking-[0.15em] text-[#A8200D] uppercase mb-4">
+                                Agency Partner Plan
                             </p>
 
-                            <ul className="space-y-3">
-                                {includedItems.map((item, index) => (
-                                    <li key={index} className="flex items-center gap-2.5">
-                                        <span className="w-1.5 h-1.5 rounded-full bg-[#A8200D] flex-shrink-0"></span>
-                                        <span className="text-gray-800 text-sm font-medium">{item}</span>
-                                    </li>
-                                ))}
-                            </ul>
+                            {/* Pricing */}
+                            <div className="mb-1">
+                                <span className="text-gray-400 text-base line-through">$350</span>
+                            </div>
+                            <div className="flex items-baseline gap-1 mb-1">
+                                <span className="text-[64px] font-bold text-gray-900 leading-none">$250</span>
+                                <span className="text-gray-500 text-base ml-1">/month</span>
+                            </div>
+                            <p className="text-gray-500 text-sm mb-4 mt-1">Billed monthly. Cancel anytime.</p>
+
+                            {/* CTA Button */}
+                            <Link
+                                href="https://buy.stripe.com/aFafZhgBudT51oZbvR2go15"
+                                className="flex items-center justify-center w-full bg-[#A8200D] hover:bg-[#8B1A0C] text-white font-semibold text-sm rounded-full py-3 px-6 transition-colors mb-5"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Become a Partner
+                            </Link>
+
+                            {/* Divider */}
+                            <div className="border-t border-[#e8e6e0] pt-4">
+                                <p className="text-[10px] font-bold tracking-[0.15em] text-gray-400 uppercase mb-4">
+                                    What&apos;s Included
+                                </p>
+
+                                <ul className="space-y-2">
+                                    {includedItems.map((item, index) => (
+                                        <li key={index} className="flex items-center gap-3">
+                                            <span className="w-2 h-2 rounded-full bg-[#A8200D] flex-shrink-0"></span>
+                                            <span className="text-gray-800 text-sm">{item}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>
+            </div>
             </div>
         </section>
     );

--- a/src/components/agencyPartner/HowItWorksSection.js
+++ b/src/components/agencyPartner/HowItWorksSection.js
@@ -10,21 +10,21 @@ const steps = [
     alt: 'Apply',
     title: '1. Apply & Set Up Your Agency',
     description:
-      'Tell us about your agency, services, and the types of clients you work with. Complete your partner profile to get started.',
+      'Tell us about your agency, services, and the clients you work with.',
   },
   {
     img: 'https://stuff.thingsofbrand.com/viasocket.com/images/img1_image-123.png',
     alt: 'Connect',
     title: '2. Connect Your Client Stack',
     description:
-      'Choose the apps, tools, and platforms your clients use most to build automations faster.',
+      'Choose the tools your clients rely on. Build automations faster.',
   },
   {
     img: 'https://stuff.thingsofbrand.com/viasocket.com/images/img7_image-124.png',
     alt: 'Launch',
     title: '3. Launch & Scale Client Automations',
     description:
-      'Access unlimited workspaces, premium features, dedicated support, and agency-first pricing as you grow.',
+      'Unlimited workspaces, premium features, and partner pricing from day one.',
   },
 ];
 

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -46,12 +46,12 @@ export default function Footer({ footerData, borderClass, isBlack = false }) {
             }
         });
     return (
-        <div className="container">
+        <div className="container overflow-hidden">
             <div
-                className={`viasocket-footer-wrapper bg-white grid lg:grid-rows-1 md:grid-cols-2 lg:grid-cols-4 grid-rows-1  ms:grid-cols-4 grid-cols-1 border ${borderTheme} ${borderClass}`}
+                className={`viasocket-footer-wrapper bg-white grid lg:grid-rows-1 md:grid-cols-2 lg:grid-cols-4 grid-rows-1  ms:grid-cols-4 grid-cols-1 border overflow-hidden ${borderTheme} ${borderClass}`}
             >
                 <div
-                    className={`row-span-1 justify-center col-span-4 lg:col-span-1 order-last lg:order-first md:p-10 p-4 h-full lg:border-r border-r-0 ${borderTheme} flex flex-col `}
+                    className={`row-span-1 justify-center col-span-4 lg:col-span-1 order-last lg:order-first md:p-10 p-4 h-full lg:border-r border-r-0 ${borderTheme} flex flex-col overflow-hidden`}
                 >
                     <p className="rotate-viasocket font-bold w-full flex justify-center items-center text-[6vw]">
                         viaSocket

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -11,6 +11,10 @@
     }
 }
 
+body, html {
+    overflow-x: hidden;
+}
+
 //check import file for imports
 @import '_import';
 


### PR DESCRIPTION
## Summary
- Redesigned `AgencyPricing` section: stat-based left column (250K / 100% / 100K), warm `#FAF9F6` card, black badge, smaller rounded CTA button
- Updated `HowItWorksSection` step descriptions with new copy
- Reduced spacing between trust text and app strip in `ShowAppsIndexOptimized`
- Fixed footer overflow: added `overflow-hidden` to footer grid wrapper and `overflow-x: hidden` globally

## Test plan
- [ ] Visit `/agency-partner` and verify pricing section layout matches design
- [ ] Check How It Works step descriptions are updated
- [ ] Verify trust text and app strip spacing is reduced in hero section
- [ ] Scroll to footer and confirm rotated "viaSocket" text no longer overflows horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)