### PR TITLE
rename expert-are-live page to experts-are-live and refine UI: rename…

### DIFF
--- a/src/app/components/home/HeroSection.js
+++ b/src/app/components/home/HeroSection.js
@@ -75,7 +75,7 @@ export default function HeroSection({ hasToken }) {
                 <div className="flex items-center gap-8 flex-wrap justify-center">
                     <CTAButtons hasToken={hasToken} />
                     <Link
-                        href="/expert-are-live"
+                        href="/experts-are-live"
                         target="_blank"
                         className="group flex items-center gap-2.5 cursor-pointer no-underline"
                     >
@@ -106,7 +106,7 @@ export default function HeroSection({ hasToken }) {
                             </span>
                         </div>
                         <span className="text-[15px] font-medium text-accent flex items-center gap-1.5 -tracking-[0.01em]">
-                            Talk to an expert{' '}
+                            Experts are live{' '}
                             <span className="text-[17px] transition-transform duration-200 group-hover:translate-x-1">
                                 →
                             </span>

--- a/src/app/experts-are-live/page.js
+++ b/src/app/experts-are-live/page.js
@@ -36,9 +36,9 @@ export default async function ExpertAreLivePage() {
 
     return (
         <>
-            <MetaHeadComp metaData={metaData} page={'/expert-are-live'} />
+            <MetaHeadComp metaData={metaData} page={'/experts-are-live'} />
             <ConditionalNavbar>
-                <NavbarServer navbarData={navbarData} utm={'/expert-are-live'} />
+                <NavbarServer navbarData={navbarData} utm={'/experts-are-live'} />
             </ConditionalNavbar>
 
             <div className="global-top-space min-h-[calc(100vh-200px)] flex flex-col items-center justify-center">
@@ -46,13 +46,13 @@ export default async function ExpertAreLivePage() {
                     {/* Hero Section */}
                     <div className="flex flex-col items-center gap-6 text-center">
                         <div className="flex items-center gap-2 bg-green-50 text-green-700 px-4 py-2 rounded-full text-sm font-medium">
-                            <span className="relative flex h-3 w-3">
+                            <span className="relative flex h-2 w-2">
                                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                                <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
+                                <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
                             </span>
-                            Experts are online now
+                            Experts are Available now
                         </div>
-                        <h1 className="h1 max-w-3xl">
+                        <h1 className="h1">
                             Get instant help from <span className="text-accent">Live Experts</span>
                         </h1>
                         <p className="text-lg text-gray-600 max-w-xl">
@@ -80,14 +80,17 @@ export default async function ExpertAreLivePage() {
                         <div className="flex items-start gap-3 bg-[#f9f7f2] border border-gray-200 rounded-lg p-4 max-w-lg">
                             <Lightbulb className="w-7 h-7 text-yellow-500 flex-shrink-0 mt-0.5" />
                             <div>
-                                <p className="text-sm text-gray-800 font-medium">Heads up! You may need to wait in a short waiting room before being connected to a live expert.</p>
+                                <p className="text-sm text-gray-800 font-medium">
+                                    Heads up! You may need to spend a short time in the waiting room before being
+                                    connected to a live expert
+                                </p>
                             </div>
                         </div>
                     </div>
 
                     {/* Support Options */}
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">
-                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl hover:shadow-lg transition-shadow duration-300">
+                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl transition-shadow duration-300">
                             <div className="w-14 h-14 rounded-full bg-blue-50 flex items-center justify-center">
                                 <Phone className="w-7 h-7 text-blue-600" />
                             </div>
@@ -97,32 +100,30 @@ export default async function ExpertAreLivePage() {
                                     Prefer a detailed conversation? We're just one call away.
                                 </p>
                             </div>
-                            <Link href="tel:+13154442439" className="btn btn-outline w-fit text-sm">
-                                Call
+                            <Link href="tel:+13154442439" className="btn btn-outline w-fit text-sm min-w-[120px]">
+                                Call Now
                             </Link>
                         </div>
 
-                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl hover:shadow-lg transition-shadow duration-300">
+                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl transition-shadow duration-300">
                             <div className="w-14 h-14 rounded-full bg-green-50 flex items-center justify-center">
                                 <MessageSquare className="w-7 h-7 text-green-600" />
                             </div>
                             <div className="flex flex-col gap-2">
                                 <h3 className="h3 text-xl">WhatsApp</h3>
-                                <p className="text-gray-600 text-sm">
-                                    On the go? Drop us a message for a quick reply.
-                                </p>
+                                <p className="text-gray-600 text-sm">On the go? Drop us a message for a quick reply.</p>
                             </div>
                             <Link
                                 href="https://wa.me/+13154442439"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="btn btn-outline w-fit text-sm"
+                                className="btn btn-outline w-fit text-sm min-w-[120px]"
                             >
                                 Start Chat
                             </Link>
                         </div>
 
-                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl hover:shadow-lg transition-shadow duration-300">
+                        <div className="flex flex-col items-center text-center gap-5 border custom-border p-8 bg-white rounded-xl transition-shadow duration-300">
                             <div className="w-14 h-14 rounded-full bg-purple-50 flex items-center justify-center">
                                 <Mail className="w-7 h-7 text-purple-600" />
                             </div>
@@ -132,7 +133,7 @@ export default async function ExpertAreLivePage() {
                                     Questions or concerns? Our inbox is always open.
                                 </p>
                             </div>
-                            <Link href="mailto:support@viasocket.com" className="btn btn-outline w-fit text-sm">
+                            <Link href="mailto:support@viasocket.com" className="btn btn-outline w-fit text-sm min-w-[120px]">
                                 Email Support
                             </Link>
                         </div>


### PR DESCRIPTION
… page route from /expert-are-live to /experts-are-live; update HeroSection link text from "Talk to an expert" to "Experts are live"; reduce online indicator size from h-3 w-3 to h-2 w-2; update status text from "Experts are online now" to "Experts are Available now"; remove max-w-3xl from h1; refine waiting room notice text; remove hover:shadow-lg from support cards; standardize button widths with min-w-[120px]; update button text from "Call" || 1