### PR TITLE
refactor embed hero components and AutomationSlugClient: standardize …

### DIFF
--- a/src/app/components/automations/AutomationSlugClient.js
+++ b/src/app/components/automations/AutomationSlugClient.js
@@ -82,7 +82,7 @@ export default function AutomationSlugClient({ pageData, hasToken }) {
                         className="w-full lg:w-[55%] flex flex-col justify-between gap-6 px-6 pt-6 pb-4"
                     >
                         <div className="cont gap-2">
-                            <h1 className="h1 !text-[40px] !leading-[1.2em] !font-semibold">{template?.title}</h1>
+                            <h1 className="h1">{template?.title}</h1>
                             <h2 className="h3 !text-lg !text-gray-500">{template?.description}</h2>
                             <div className="flex items-center gap-4 mt-6">
                                 <button
@@ -189,7 +189,7 @@ export default function AutomationSlugClient({ pageData, hasToken }) {
                             <ReactMarkdown
                                 components={{
                                     h1: ({ node, ...props }) => (
-                                        <h1 {...props} className="text-3xl font-bold mb-4 text-black-900" />
+                                        <h2 {...props} className="h2" />
                                     ),
                                     h2: ({ node, ...props }) => (
                                         <h2 {...props} className="text-2xl font-bold mb-3 mt-6 text-black-900" />

--- a/src/app/components/embed/EmbedHero.js
+++ b/src/app/components/embed/EmbedHero.js
@@ -32,7 +32,7 @@ export default function EmbedHero({ appCount }) {
                 <span>Users can connect apps and build workflows without leaving your platform.</span>
             </div>
 
-            <HeroCtaButtons signupHref="/signup?utm_source=/embed" salesHref="https://cal.id/team/viasocket/embed" className="flex items-center gap-4 mt-8 mb-8" />
+            <HeroCtaButtons signupHref="/signup?utm_source=/embed" salesHref="https://cal.id/team/viasocket/embed" className="flex items-center gap-4 mt-8 mb-8" salesClassName="text-black underline" />
         </div>
     );
 }

--- a/src/app/components/embed/HeroCtaButtons.js
+++ b/src/app/components/embed/HeroCtaButtons.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 
-export default function HeroCtaButtons({ signupHref, salesHref = 'https://cal.id/team/viasocket/sales-team', className = 'flex gap-3 sm:gap-4 md:gap-6 items-center justify-start w-full' }) {
+export default function HeroCtaButtons({ signupHref, salesHref = 'https://cal.id/team/viasocket/sales-team', className = 'flex gap-3 sm:gap-4 md:gap-6 items-center justify-start w-full', salesClassName = 'text-white/80 hover:text-white underline' }) {
     return (
         <div className={className}>
             <Link href={signupHref} className="btn btn-outline">
@@ -10,7 +10,7 @@ export default function HeroCtaButtons({ signupHref, salesHref = 'https://cal.id
             </Link>
             <Link
                 href={salesHref}
-                className="text-white/80 hover:text-white underline"
+                className={salesClassName}
                 target="_blank"
             >
                 Contact Sales

--- a/src/app/embed/actions-for-ai/HeroAurora.js
+++ b/src/app/embed/actions-for-ai/HeroAurora.js
@@ -59,12 +59,10 @@ export default function HeroAurora({ appCount }) {
         <>
             <section className="relative bg-transparent container">
                 <EmbedBreadcrumbs currentPage="Action for AI" />
-                <div className="relative flex items-center justify-center lg:min-h-[520px] overflow-hidden border border-white/10 bg-[#1A0A3E]">
-                    <div className="relative z-[2] w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-2 gap-12 items-center px-8 py-16 lg:px-12 lg:py-24">
-                        <HeroContent agent={agent} appCount={appCount} />
+                <div className="relative z-[2] w-full lg:min-h-[580px] overflow-hidden border border-white/10 bg-[#1A0A3E] grid grid-cols-1 lg:grid-cols-2 gap-12 items-center p-6 lg:p-12">
+                    <HeroContent agent={agent} appCount={appCount} />
 
-                        <AgentDiagram agent={agent} />
-                    </div>
+                    <AgentDiagram agent={agent} />
                 </div>
             </section>
         </>

--- a/src/app/embed/actions-for-ai/HeroContent.js
+++ b/src/app/embed/actions-for-ai/HeroContent.js
@@ -6,9 +6,9 @@ import HeroCtaButtons from '@/app/components/embed/HeroCtaButtons';
 
 export default function HeroContent({ appCount }) {
     return (
-        <div className="flex flex-col items-start text-left">
+        <div className="flex flex-col items-start text-left gap-4">
             <LimitedTimeOffer href="https://viasocket.com/signup?utm_source=/embed/actions-for-ai" />
-            <h1 className="h1 !text-white !text-2xl sm:!text-3xl md:!text-4xl lg:!text-5xl mb-2">Give your AI Agents the Power to Act</h1>
+            <h1 className="h1 !text-white">Give your AI Agents the Power to Act</h1>
 
             <p className="text-base sm:text-lg md:text-xl leading-[1.55] text-white/80 mb-6 md:mb-8 max-w-[460px]">
                 Your users connect {appCount + 300}+ apps, <br /> callable by your AI as tools or MCP servers

--- a/src/app/embed/actions-via-webhook/WebhookHero.js
+++ b/src/app/embed/actions-via-webhook/WebhookHero.js
@@ -175,7 +175,7 @@ export default function WebhookHero({ appCount }) {
                     />
 
                     {/* Content */}
-                    <div className="relative z-10 p-6 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:min-h-[520px] items-center">
+                    <div className="relative z-10 p-6 lg:p-12 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:min-h-[580px] items-center">
                         {/* Left */}
                         <div className="flex flex-col gap-2">
                             <LimitedTimeOffer href="https://viasocket.com/signup?utm_source=/embed/actions-for-ai" />

--- a/src/app/embed/app-integration/HeroAurora.js
+++ b/src/app/embed/app-integration/HeroAurora.js
@@ -23,10 +23,10 @@ export default function HeroAurora({ appCount }) {
                     <div className="absolute rounded-full blur-[100px] pointer-events-none w-[520px] h-[520px] bg-[#063826] left-[40%] -bottom-[18%] opacity-18 max-md:blur-[60px]" />
                     <div className="aurora-grid-bg" />
 
-                    <div className="relative z-10 p-6 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:min-h-[520px] items-center">
-                        <div className="flex flex-col items-start">
+                    <div className="relative z-10 p-6 lg:p-12 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:min-h-[580px] items-center">
+                        <div className="flex flex-col items-start gap-4">
                             <LimitedTimeOffer href="https://viasocket.com/signup?utm_source=/embed/actions-for-ai" />
-                            <h1 className="h1 !text-white !text-2xl sm:!text-3xl md:!text-4xl lg:!text-5xl">Integrate {appCount + 300}+ apps with your product</h1>
+                            <h1 className="h1 !text-white">Integrate {appCount + 300}+ apps with your product</h1>
 
                             <p className="text-base sm:text-lg md:text-xl text-white/[0.72] max-w-[480px] mb-6 md:mb-8 leading-[1.55] font-normal max-lg:mx-auto">
                                 Give users the ability to connect the tools they use with your product and automate it.

--- a/src/app/embed/app-integration/WorkflowIllustration.js
+++ b/src/app/embed/app-integration/WorkflowIllustration.js
@@ -121,7 +121,7 @@ export default function WorkflowIllustration() {
                                 style={{ animationDelay: '.45s' }}
                             >
                                 <div className="absolute -inset-[2px] rounded-[12px] border-2 border-[rgba(5,150,105,.25)] animate-[fnPulseRing_2.5s_ease-in-out_infinite] pointer-events-none" />
-                                <div className="w-9 h-9 flex items-center justify-center shrink-0 overflow-hidden">
+                                <div className="w-9 h-9 rounded-lg bg-[#f4f4f5] border flex items-center justify-center shrink-0 overflow-hidden">
                                     <Image
                                         src="https://thingsofbrand.com/api/icon/hubspot.com"
                                         alt="HubSpot"


### PR DESCRIPTION
…heading styles by removing custom text size classes in favor of default h1/h2 classes across HeroContent and AutomationSlugClient; add salesClassName prop to HeroCtaButtons with default "text-white/80 hover:text-white underline" and pass "text-black underline" variant in EmbedHero; update hero section layouts from nested containers to single grid with consistent p-6 lg:p-12 padding and lg:min-h-[580px] across HeroAurora, WebhookH || 1