### PR TITLE
Fix spacing in agency hero & add agency partner link on pricing page

### DIFF
--- a/src/app/pricing/page.js
+++ b/src/app/pricing/page.js
@@ -67,6 +67,9 @@ export default async function PricingPage() {
                             Free call with automation experts
                         </Link>
                     </div>
+                    <Link href="/agency-partner" className="text-lg text-accent underline">
+                        Special pricing for agency partners →
+                    </Link>
                 </div>
 
                 <div className="flex items-center justify-center">

--- a/src/components/agencyPartner/HeroSection.js
+++ b/src/components/agencyPartner/HeroSection.js
@@ -18,8 +18,7 @@ const HeroSection = ({ appCount }) => {
                 {/* Heading */}
                 <h1 className="h1 mb-4">
                     Build automations for clients, <br />
-                    with
-                    <span className="text-[#a8200d]">viaSocket.</span>
+                    with <span className="text-[#a8200d]">viaSocket.</span>
                 </h1>
 
                 {/* Description */}


### PR DESCRIPTION
## Summary
- Fixed missing space between "with" and "viaSocket" in the agency partner hero heading
- Added "Special pricing for agency partners →" link below the CTA buttons on the pricing page, underlined, linking to `/agency-partner`

## Test plan
- [ ] Visit `/agency-partner` — hero heading should read "with viaSocket." with a space
- [ ] Visit `/pricing` — link "Special pricing for agency partners →" should appear below CTA buttons, underlined, and redirect to `/agency-partner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)