### PR TITLE
Update MCP redirect URLs and embed page metadata handling

### DIFF
--- a/src/app/components/navbar/MainNavbar.js
+++ b/src/app/components/navbar/MainNavbar.js
@@ -81,8 +81,10 @@ export default function MainNavbar({
                                 handleRedirect(
                                     e,
                                     pathname?.startsWith('/mcp')
-                                        ? 'https://flow.viasocket.com/mcp?'
-                                        : 'https://flow.viasocket.com?'
+                                        ? 'https://mushrooms.viasocket.com?'
+                                        : 'https://flow.viasocket.com?',
+                                    null,
+                                    pathname?.startsWith('/mcp') ? 'viasocket' : undefined
                                 )
                             }
                             rel="nofollow"
@@ -95,7 +97,9 @@ export default function MainNavbar({
                             onClick={(e) =>
                                 handleRedirect(
                                     e,
-                                    pathname?.startsWith('/mcp') ? 'https://flow.viasocket.com/mcp?' : '/signup?'
+                                    pathname?.startsWith('/mcp') ? 'https://mushrooms.viasocket.com?' : '/signup?',
+                                    null,
+                                    pathname?.startsWith('/mcp') ? 'viasocket' : undefined
                                 )
                             }
                         >

--- a/src/app/embed/actions-for-ai/page.js
+++ b/src/app/embed/actions-for-ai/page.js
@@ -21,9 +21,9 @@ import { getFaqData } from '@/utils/getFaqData';
 export const runtime = 'edge';
 
 export async function generateMetadata() {
-    const { metaData, appCount } = await getEmbedPageData();
-    const fallbackTitle = `The embedded MCP server for AI products. Connect your AI to ${appCount + 300}+ app actions through one viaSocket Embed. Multi-step workflows your users build, your AI calls as single tools.`;
-    const fallbackDesc = `The embedded MCP server for AI products. Connect your AI to ${appCount + 300}+ app actions through one viaSocket Embed. Multi-step workflows your users build, your AI calls as single tools.`;
+    const { metaData, appCount } = await getEmbedPageData('actions-for-ai');
+    const fallbackTitle = `The Embedded MCP server for AI products.`;
+    const fallbackDesc = `Connect your AI to ${appCount + 300}+ app actions through one viaSocket Embed. Multi-step workflows your users build, your AI calls as single tools.`;
 
     return {
         title: metaData?.title || fallbackTitle,
@@ -45,7 +45,7 @@ export async function generateMetadata() {
 
 export default async function ActionForAiPage() {
     const { navbarData, footerData, blogData, securityGridData, appCount, metaData } =
-        await getEmbedPageData();
+        await getEmbedPageData('actions-for-ai');
 
     const actionForAiFaq = await getFaqData('/embed/actions-for-ai', '');
 

--- a/src/app/embed/actions-via-webhook/page.js
+++ b/src/app/embed/actions-via-webhook/page.js
@@ -20,7 +20,7 @@ import { getFaqData } from '@/utils/getFaqData';
 export const runtime = 'edge';
 
 export async function generateMetadata() {
-    const { metaData } = await getEmbedPageData();
+    const { metaData } = await getEmbedPageData('actions-via-webhook');
 
     return {
         title: metaData?.title || 'Actions via Webhook | Webhook Automation Platform | viaSocket Embed',
@@ -47,7 +47,7 @@ export async function generateMetadata() {
 }
 
 export default async function ActionViaWebhookPage() {
-    const { navbarData, footerData, blogData, securityGridData, appCount, metaData } = await getEmbedPageData();
+    const { navbarData, footerData, blogData, securityGridData, appCount, metaData } = await getEmbedPageData('actions-via-webhook');
 
     const actionViaWebhookFaq = await getFaqData('/embed/actions-via-webhook', '');
 

--- a/src/app/embed/app-integration/page.js
+++ b/src/app/embed/app-integration/page.js
@@ -21,7 +21,7 @@ import { getFaqData } from '@/utils/getFaqData';
 export const runtime = 'edge';
 
 export async function generateMetadata() {
-    const { metaData } = await getEmbedPageData();
+    const { metaData } = await getEmbedPageData('app-integration');
 
     return {
         title: metaData?.title || 'App Integrations | Embedded iPaaS for SaaS | viaSocket Embed',
@@ -47,7 +47,7 @@ export async function generateMetadata() {
 
 export default async function AppIntegrationsPage() {
     const { navbarData, footerData, blogData, securityGridData, appCount, metaData } =
-        await getEmbedPageData();
+        await getEmbedPageData('app-integration');
 
     const appIntegrationFaq = await getFaqData('/embed/app-integration', '');
 

--- a/src/app/lib/data.js
+++ b/src/app/lib/data.js
@@ -517,17 +517,20 @@ export async function getExpertsPageData() {
     }
 }
 
-export async function getEmbedPageData() {
+export async function getEmbedPageData(slug = '') {
     try {
         const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://viasocket.com';
-        const pageUrl = `${baseUrl}/embed`;
+        const pagePath = slug ? `/embed/${slug}` : '/embed';
+        const pageUrl = `${baseUrl}${pagePath}`;
+        const metaName = slug ? `/embed/${slug}` : '/embed';
+        const faqName = slug ? `/embed/${slug}` : '/embed';
 
         // Fetch dynamic data in parallel
         const [metaData, footerData, navbarData, faqData, embedData, blogData, appCount] = await Promise.all([
-            getMetaData('/embed', pageUrl),
+            getMetaData(metaName, pageUrl),
             getFooterData(FOOTER_FIELDS, '', pageUrl),
             getNavbarData(NAVBAR_FIELDS, '', pageUrl),
-            getFaqData('/embed', pageUrl),
+            getFaqData(faqName, pageUrl),
             getEmbedData(EMBED_FIELDS, '', pageUrl),
             getBlogData({ tag1: 'embed' }, pageUrl),
             getAppCount(pageUrl),

--- a/src/components/agencyPartner/AgencyPricing.js
+++ b/src/components/agencyPartner/AgencyPricing.js
@@ -79,7 +79,7 @@ const AgencyPricing = () => {
                             <span className="text-gray-400 text-sm line-through">$350</span>
                         </div>
                         <div className="flex items-baseline gap-1 mb-1">
-                            <span className="text-5xl font-bold text-gray-900">$263</span>
+                            <span className="text-5xl font-bold text-gray-900">$250</span>
                             <span className="text-gray-500 text-base">/month</span>
                         </div>
                         <p className="text-gray-500 text-xs mb-6">Billed monthly. Cancel anytime.</p>

--- a/src/utils/handleRedirection.js
+++ b/src/utils/handleRedirection.js
@@ -2,9 +2,18 @@ import { setUtmSource } from './handleUtmSource';
 
 export const handleRedirect = (e, url, router, customSource) => {
     e.preventDefault();
-    const source = customSource || (typeof window !== 'undefined' ? window.location.pathname : '');
-    const utmParams = setUtmSource({ source });
-    const finalUrl = `${url}state=${utmParams}`;
+    const baseUrl = url.replace(/\?$/, '');
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    let finalUrl;
+
+    if (customSource) {
+        const utmState = JSON.stringify({ utm_source: customSource });
+        finalUrl = `${baseUrl}${separator}state=${utmState}&utm_source=${customSource}`;
+    } else {
+        const source = typeof window !== 'undefined' ? window.location.pathname : '';
+        const utmParams = setUtmSource({ source });
+        finalUrl = `${baseUrl}${separator}state=${utmParams}`;
+    }
 
     if (router && url.startsWith('/')) {
         router.push(finalUrl);


### PR DESCRIPTION
- Change MCP navbar redirects from flow.viasocket.com/mcp to mushrooms.viasocket.com
- Add custom utm_source parameter 'viasocket' for MCP redirects
- Pass slug parameter to getEmbedPageData() for actions-for-ai, actions-via-webhook, and app-integration pages
- Update actions-for-ai metadata: shorten fallback title and split description
- Refactor handleRedirect to support custom utm_source with proper URL parameter handling || 1