### PR TITLE
Update security badge image URLs to use CDN hosting

### DIFF
--- a/src/app/components/SecuritySection.js
+++ b/src/app/components/SecuritySection.js
@@ -17,13 +17,13 @@ export default function SecuritySection({ securityGridData }) {
                     </div>
                     <div className="flex gap-4">
                         <Image
-                            src="https://viasocket.com/assets/img/aicpa-soc-badge.webp"
+                            src="https://stuff.thingsofbrand.com/viasocket.com/images/img8_image-28.png"
                             alt="aicpa soc badge"
                             width={80}
                             height={80}
                         />
                         <Image
-                            src="https://viasocket.com/assets/img/iso-certified.webp"
+                            src="https://stuff.thingsofbrand.com/viasocket.com/images/img2_image-29.png"
                             alt="iso certified badge"
                             width={80}
                             height={80}

--- a/src/app/components/new-home/SecuritySectionNew.js
+++ b/src/app/components/new-home/SecuritySectionNew.js
@@ -1,7 +1,7 @@
 import Image from "next/image";
 
-const socBadge = "https://viasocket.com/assets/img/aicpa-soc-badge.webp";
-const isoBadge = "https://viasocket.com/assets/img/iso-certified.webp";
+const socBadge = "https://stuff.thingsofbrand.com/viasocket.com/images/img8_image-28.png";
+const isoBadge = "https://stuff.thingsofbrand.com/viasocket.com/images/img2_image-29.png";
 
 export default function SecuritySectionNew({ securityGridData = [] }) {
   return (


### PR DESCRIPTION
- Replace AICPA SOC badge URL from viasocket.com/assets to stuff.thingsofbrand.com CDN
- Replace ISO certified badge URL from viasocket.com/assets to stuff.thingsofbrand.com CDN
- Update badge URLs in both SecuritySection and SecuritySectionNew components || TEST