### PR TITLE
Redesign IntegrationsPreview to show live template cards and add tabb…

### DIFF
--- a/src/app/components/embed/WorkflowIllustration.js
+++ b/src/app/components/embed/WorkflowIllustration.js
@@ -5,7 +5,7 @@ export default function WorkflowIllustration() {
     return (
         <div className="mt-auto flex items-center gap-3.5 pt-8">
             <div className="w-[54px] h-[54px] bg-gradient-to-br from-[#7c3aed] via-[#a78bfa] to-[#c4b5fd] flex items-center justify-center shrink-0 rounded-[10px] relative animate-feat-spark-glow">
-                <div className="absolute -inset-1.5 rounded-[14px] bg-[radial-gradient(circle,rgba(124,58,237,0.35)_0%,transparent_70%)] z-0 animate-feat-spark-halo pointer-events-none" />
+                <div className="absolute -inset-1.5 rounded-lg bg-[radial-gradient(circle,rgba(124,58,237,0.35)_0%,transparent_70%)] z-0 animate-feat-spark-halo pointer-events-none" />
                 <Sparkles color="white" size={28} className="relative z-[1] drop-shadow-[0_1px_2px_rgba(0,0,0,0.18)] animate-feat-spark-float" />
             </div>
             <div

--- a/src/app/components/integrations-script/HowItWorks.js
+++ b/src/app/components/integrations-script/HowItWorks.js
@@ -57,7 +57,7 @@ function Step({ index, title, desc, visual }) {
     return (
         <div className="flex flex-col">
             <div className="mb-3 text-center text-[11px] font-bold uppercase tracking-[1.6px] text-accent">{index}</div>
-            <div className="flex h-[200px] items-center justify-center rounded-[14px] border border-[#ece9df] bg-[#faf9f4] p-4">
+            <div className="flex h-[200px] items-center justify-center rounded-lg border border-[#ece9df] bg-[#faf9f4] p-4">
                 {visual}
             </div>
             <h3 className="mt-5 text-[17px] font-bold text-[#1a1a1a]">{title}</h3>

--- a/src/app/components/integrations-script/IntegrationsPreview.js
+++ b/src/app/components/integrations-script/IntegrationsPreview.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { Lock, Link2, Code2, ArrowRight, Boxes } from 'lucide-react';
+import { ArrowRight, Boxes, Link2 } from 'lucide-react';
 import Image from 'next/image';
 
 const TEMPLATES = [
@@ -8,100 +8,87 @@ const TEMPLATES = [
     'New {{app}} message → create a record in YourApp',
     'Daily summary from YourApp → send to a {{app}} channel',
     'Status changed in YourApp → alert your team on {{app}}',
+    'New file uploaded in YourApp → share it in {{app}}',
+    'Task completed in YourApp → notify the owner on {{app}}',
 ];
 
-export default function IntegrationsPreview({ current }) {
+const PLACEHOLDER = { name: 'Your app', logo: null };
+
+function AppIcon({ app }) {
+    if (app?.logo) {
+        return (
+            <Image
+                src={app.logo}
+                alt={app.name}
+                width={28}
+                height={28}
+                className="h-7 w-7 object-contain"
+            />
+        );
+    }
     return (
-        <div className="relative" aria-hidden="true">
-            <div className="overflow-hidden rounded-2xl border border-[#ece9df] bg-white shadow-sm">
-                {/* host bar */}
-                <div className="flex items-center gap-2 border-b border-[#ece9df] bg-[#faf9f4] px-4 py-[11px]">
-                    <div className="flex gap-[5px]">
-                        <span className="h-[9px] w-[9px] rounded-full bg-[#e2e0d8]" />
-                        <span className="h-[9px] w-[9px] rounded-full bg-[#e2e0d8]" />
-                        <span className="h-[9px] w-[9px] rounded-full bg-[#e2e0d8]" />
-                    </div>
-                    <div className="flex flex-1 items-center gap-[6px] rounded-[7px] border border-[#ece9df] bg-white px-[11px] py-[5px] text-[11px] text-[#8a8a8a]">
-                        <Lock className="h-[10px] w-[10px] text-[#2f8a4a]" strokeWidth={1.8} />
-                        <b className="font-semibold text-[#5a5a5a]">yourproduct.com</b>/integrations
-                    </div>
-                </div>
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#f3f2ec] text-[#8a8a8a]">
+            <Boxes className="h-4 w-4" />
+        </span>
+    );
+}
 
-                {/* head */}
-                <div className="flex items-center justify-between px-[18px] pb-[14px] pt-4">
-                    <div className="flex items-center gap-[11px]">
-                        <span className="flex h-[30px] w-[30px] items-center justify-center rounded-lg bg-[#4b5563]">
-                            <Link2 className="h-4 w-4 text-white" strokeWidth={2.4} />
-                        </span>
-                        <div>
-                            <div className="text-[15px] font-bold leading-[1.1] tracking-[-0.2px] text-[#1a1a1a]">
-                                Popular integrations
-                            </div>
-                            <div className="mt-[2px] text-[11px] text-[#5a5a5a]">
-                                Powered by viaSocket · <span>YourApp + {current.name}</span>
-                            </div>
-                        </div>
-                    </div>
-                    <span className="flex items-center gap-[6px] rounded-full border border-[#cfe6d5] bg-[#eaf6ee] px-[10px] py-[4px] text-[10px] font-bold tracking-[0.6px] text-[#2f8a4a]">
-                        <span className="h-[6px] w-[6px] animate-pulse rounded-full bg-[#2f8a4a]" />
-                        LIVE
+export default function IntegrationsPreview({ current }) {
+    const app = current || PLACEHOLDER;
+    const yourApp = PLACEHOLDER;
+    return (
+        <div aria-hidden="true">
+            <div className="flex items-center justify-between pb-[14px]">
+                <div className="flex items-center gap-[11px]">
+                    <span className="flex h-[30px] w-[30px] items-center justify-center rounded-lg bg-[#4b5563]">
+                        <Link2 className="h-4 w-4 text-white" strokeWidth={2.4} />
                     </span>
-                </div>
-
-                {/* templates grid */}
-                <div className="grid grid-cols-1 gap-[11px] px-[18px] pb-[18px] sm:grid-cols-2">
-                    {TEMPLATES.map((tpl, i) => (
-                        <div
-                            key={i}
-                            className={`group flex flex-col gap-[10px] rounded-[11px] border border-[#ece9df] bg-white p-[14px] transition-all duration-300 hover:-translate-y-[2px] hover:shadow-[0_10px_24px_-12px_rgba(26,26,26,0.2)] ${
-                                i === 3 ? 'hidden sm:flex' : ''
-                            }`}
-                        >
-                            <div className="flex items-center gap-[7px]">
-                                <span className="flex h-[30px] w-[30px] flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[#4b5563] bg-[#4b5563]">
-                                    <Boxes className="h-4 w-4 text-white" />
-                                </span>
-                                <span className="font-semibold text-[#cbc9c1]">+</span>
-                                <span className="flex h-[30px] w-[30px] flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[#ece9df] bg-[#faf9f4]">
-                                    <Image
-                                        src={current.logo}
-                                        alt={current.name}
-                                        width={19}
-                                        height={19}
-                                        className="h-[19px] w-[19px] object-contain animate-fadeSlideIn [animation-duration:500ms] [animation-timing-function:cubic-bezier(0.22,1,0.36,1)]"
-                                    />
-                                </span>
-                            </div>
-                            <div className="text-sm font-semibold leading-[1.4] text-[#2a2a2a]">
-                                {tpl.split('{{app}}').map((part, idx, arr) => (
-                                    <span key={idx}>
-                                        {part}
-                                        {idx < arr.length - 1 && <span className="text-accent">{current.name}</span>}
-                                    </span>
-                                ))}
-                            </div>
-                            <div className="mt-auto flex items-center justify-between">
-                                <span className="rounded-full border border-[#ece9df] bg-[#f3f2ec] px-[10px] py-[4px] text-[10px] font-bold uppercase tracking-[0.3px] text-[#595959]">
-                                    Use template
-                                </span>
-                                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-[#f3f2ec] text-[#5a5a5a]">
-                                    <ArrowRight className="h-[10px] w-[10px]" strokeWidth={2} />
-                                </span>
-                            </div>
+                    <div>
+                        <div className="text-[15px] font-bold leading-[1.1] tracking-[-0.2px] text-[#1a1a1a]">
+                            Popular integrations
                         </div>
-                    ))}
+                        <div className="mt-[2px] text-[11px] text-[#5a5a5a]">
+                            Powered by viaSocket · <span>YourApp + {app.name}</span>
+                        </div>
+                    </div>
                 </div>
+                <span className="flex items-center gap-[6px] rounded-full border border-[#cfe6d5] bg-[#eaf6ee] px-[10px] py-[4px] text-[10px] font-bold tracking-[0.6px] text-[#2f8a4a]">
+                    <span className="h-[6px] w-[6px] animate-pulse rounded-full bg-[#2f8a4a]" />
+                    LIVE
+                </span>
             </div>
 
-            {/* floating widget */}
-            <div className="absolute -bottom-[18px] -left-[18px] hidden items-center gap-[11px] rounded-xl border border-[#ece9df] bg-white px-3 py-2 sm:flex">
-                <span className="flex h-[34px] w-[34px] items-center justify-center rounded-[9px] border border-[#ecd9a4] bg-[#fbf4e1] text-[#b8860b]">
-                    <Code2 className="h-[17px] w-[17px]" strokeWidth={2} />
-                </span>
-                <div className="flex flex-col gap-1">
-                    <span className="text-sm font-bold">1 script tag</span>
-                    <span className="text-xs text-[#5a5a5a]">renders every template</span>
-                </div>
+            <div className="grid grid-cols-1 gap-[14px] sm:grid-cols-2 lg:grid-cols-3">
+                {TEMPLATES.map((tpl, i) => {
+                    const [first, second] = i % 2 === 0 ? [yourApp, app] : [app, yourApp];
+                    return (
+                        <div
+                            key={i}
+                            className="group flex min-h-[220px] flex-col justify-between rounded-[6px] border border-[#ece9df] bg-white p-5 transition-all duration-300 hover:-translate-y-[2px] hover:shadow-[0_10px_24px_-12px_rgba(26,26,26,0.2)]"
+                        >
+                            <div>
+                                <div className="mb-4 flex items-center gap-2">
+                                    <AppIcon app={first} />
+                                    <AppIcon app={second} />
+                                </div>
+                                <div className="text-[15px] leading-[1.5] text-[#1a1a1a]">
+                                    {tpl.split('{{app}}').map((part, idx, arr) => (
+                                        <span key={idx}>
+                                            {part}
+                                            {idx < arr.length - 1 && <span>{app.name}</span>}
+                                        </span>
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="mt-4 flex justify-end">
+                                <span className="inline-flex items-center gap-1 text-[12px] font-bold uppercase tracking-[0.6px] text-[#1a1a1a]">
+                                    Try it
+                                    <ArrowRight className="h-[12px] w-[12px]" strokeWidth={2} />
+                                </span>
+                            </div>
+                        </div>
+                    );
+                })}
             </div>
         </div>
     );

--- a/src/app/components/integrations-script/ScriptOutput.js
+++ b/src/app/components/integrations-script/ScriptOutput.js
@@ -1,117 +1,132 @@
 'use client';
 
-import Link from 'next/link';
-import { Copy, Info, Check } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { Copy, Check } from 'lucide-react';
+import IntegrationsPreview from './IntegrationsPreview';
+
+const APP_ATTRIBUTES = Array.from({ length: 10 }, (_, i) => `appName${i + 1}`);
+
+const PAIRS = [
+    { name: 'Slack', logo: 'https://stuff.thingsofbrand.com/slack.com/images/img668216333e_slack.jpg' },
+    { name: 'Google Sheets', logo: 'https://stuff.thingsofbrand.com/google.com/images/img4_googlesheet.png' },
+    { name: 'HubSpot', logo: 'https://stuff.thingsofbrand.com/hubspot.com/images/img61728fea98_hubspot.jpg' },
+    { name: 'Gmail', logo: 'https://stuff.thingsofbrand.com/gmail.com/images/imge_idrA5FDGTH_1763454052978.svg' },
+];
 
 export default function ScriptOutput({ scriptCode, canCopy, copied, onCopy }) {
-    return (
-        <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-            <div>
-                <div className="overflow-hidden rounded-[14px] border border-[#ece9df] bg-[#0f1115]">
-                    <pre className="max-h-[360px] overflow-auto p-5 text-[13px] leading-[1.6] text-[#e6e6e6]">
-                        <code className="!bg-transparent !p-0 !text-[#e6e6e6]">{scriptCode}</code>
-                    </pre>
-                    <div className="flex items-center justify-between border-t border-white/10 bg-[#15171c] px-4 py-2.5">
-                        <span className="text-[12px] font-semibold uppercase tracking-[1px] text-[#8a8a8a]">
-                            Your script
-                        </span>
-                        <button
-                            type="button"
-                            disabled={!canCopy}
-                            onClick={onCopy}
-                            className={`inline-flex items-center gap-1.5 rounded-[8px] border px-3 py-1.5 text-[12.5px] font-semibold transition ${
-                                canCopy
-                                    ? 'border-white/20 bg-white/5 text-white hover:bg-white/10'
-                                    : 'cursor-not-allowed border-white/10 bg-white/5 text-[#6a6a6a]'
-                            }`}
-                        >
-                            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                            {copied ? 'Copied' : 'Copy'}
-                        </button>
-                    </div>
-                </div>
-                <div className="mt-3 flex items-start gap-2 rounded-md border border-[#ece9df] bg-[#faf9f4] p-3 text-[13px] leading-[1.55] text-[#5a5a5a]">
-                    <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-accent" />
-                    <span>
-                        Pick your app, then the apps to feature. Each one drops into the script automatically and empty
-                        slots are skipped when you copy. You can select a maximum of 10 apps to feature. Don&apos;t see your app?{' '}
-                        <Link
-                            href="https://viasocket.com/help/viasocket-embed/Discover-the-Power-of-Automation-with-viasocket-Integration-Script"
-                            className="font-semibold text-accent hover:underline"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Browse the full directory
-                        </Link>
-                        .
-                    </span>
-                </div>
-            </div>
+    const [activeTab, setActiveTab] = useState('preview');
+    const [pairIdx, setPairIdx] = useState(0);
+    const previewRef = useRef(null);
 
-            <div className="flex flex-col gap-3">
-                <ParamRow
-                    name="primaryApp"
-                    required
-                    desc={
-                        <>
-                            Your platform, the main app every template is built around. Use your app&apos;s slug, e.g.{' '}
-                            <Code>your_app_slug</Code>.
-                        </>
-                    }
-                />
-                <ParamRow
-                    name="appName1 … appName10"
-                    desc={
-                        <>
-                            The apps to feature alongside your app, each as a slug like <Code>slack</Code> or{' '}
-                            <Code>google-sheets</Code>. Add anywhere from 2 up to 10 per script.
-                        </>
-                    }
-                />
-                <ParamRow
-                    name="id"
-                    required
-                    desc={
-                        <>
-                            Must be <Code>viasocket_integrations</Code>. This is how the script mounts the widget on
-                            your page.
-                        </>
-                    }
-                />
-                <ParamRow
-                    name="src"
-                    required
-                    desc={
-                        <>
-                            Always <Code>https://integrations.viasocket.com/integrations.js</Code>.
-                        </>
-                    }
-                />
-            </div>
-        </div>
+    useEffect(() => {
+        const id = setInterval(() => setPairIdx((i) => (i + 1) % PAIRS.length), 4500);
+        return () => clearInterval(id);
+    }, []);
+
+    const currentPair = PAIRS[pairIdx];
+
+    useEffect(() => {
+        const container = previewRef.current;
+        if (!container) return;
+
+        container.innerHTML = '';
+
+        if (!canCopy || !scriptCode) return;
+
+        const doc = new DOMParser().parseFromString(scriptCode, 'text/html');
+        const sourceScript = doc.querySelector('script');
+
+        if (!sourceScript?.src) return;
+
+        const script = document.createElement('script');
+
+        ['primaryApp', 'id', 'crossorigin'].forEach((attr) => {
+            const value = sourceScript.getAttribute(attr);
+
+            if (!value) return;
+
+            if (attr === 'id') script.id = value;
+            else if (attr === 'crossorigin') script.crossOrigin = value;
+            else script.setAttribute(attr, value);
+        });
+
+        APP_ATTRIBUTES.forEach((attr) => {
+            const value = sourceScript.getAttribute(attr);
+            if (value) script.setAttribute(attr, value);
+        });
+
+        script.src = sourceScript.src;
+
+        container.appendChild(script);
+
+        const CSS = `.container-viasocket-integrations{margin:0 !important;}`;
+        const inject = (root) => {
+            if (!root || root.querySelector('style[data-vs-reset]')) return;
+            const s = Object.assign(document.createElement('style'), { textContent: CSS });
+            s.dataset.vsReset = '';
+            root.appendChild(s);
+        };
+        const observer = new MutationObserver(() =>
+            container.querySelectorAll('*').forEach((el) => el.shadowRoot && inject(el.shadowRoot))
+        );
+        observer.observe(container, { childList: true, subtree: true });
+
+        return () => {
+            observer.disconnect();
+            container.innerHTML = '';
+        };
+    }, [scriptCode, canCopy]);
+
+    const tabButton = (tab, label) => (
+        <button
+            type="button"
+            onClick={() => setActiveTab(tab)}
+            className={`rounded-md px-3 py-1.5 text-[13px] font-semibold transition ${activeTab === tab ? 'bg-white text-accent shadow-sm' : 'text-[#8a8a8a] hover:text-[#1a1a1a]'
+                }`}
+        >
+            {label}
+        </button>
     );
-}
 
-function ParamRow({ name, required, desc }) {
     return (
-        <div className="rounded-[12px] border border-[#ece9df] bg-white p-4">
-            <div className="mb-1.5 flex items-center gap-2">
-                <Code>{name}</Code>
-                <span
-                    className={`rounded-full px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-[0.6px] ${
-                        required ? 'bg-accent/10 text-accent' : 'bg-[#f1ede0] text-[#8a6a3a]'
-                    }`}
+        <div className="overflow-hidden rounded-lg border border-[#ece9df] bg-[#faf9f4] h-full pb-10">
+            {/* Header */}
+            <div className="flex items-center justify-between border-b border-[#ece9df] px-4 py-3">
+                <div className="flex gap-1">
+                    {tabButton('preview', 'Preview')}
+                    {tabButton('code', 'Code')}
+                </div>
+
+                <button
+                    type="button"
+                    disabled={!canCopy}
+                    onClick={onCopy}
+                    className={`inline-flex items-center gap-1.5 rounded-[8px] border px-3 py-1.5 text-[12.5px] font-semibold transition ${canCopy
+                        ? 'border-[#e2dfd2] bg-white text-accent hover:border-accent'
+                        : 'cursor-not-allowed border-[#e2dfd2] bg-white text-[#6a6a6a]'
+                        }`}
                 >
-                    {required ? 'Required' : 'Optional'}
-                </span>
+                    {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                    {copied ? 'Copied' : 'Copy Code'}
+                </button>
             </div>
-            <div className="text-[13.5px] leading-[1.55] text-[#5a5a5a]">{desc}</div>
-        </div>
-    );
-}
 
-function Code({ children }) {
-    return (
-        <code className="rounded-[5px] bg-accent/10 px-1.5 py-0.5 font-mono text-[12.5px] text-accent">{children}</code>
+            {/* Body */}
+            <div className={`bg-[#0f1115] min-h-full h-full ${activeTab === 'code' ? '' : 'hidden'}`}>
+                <pre className="p-5 text-sm leading-[1.6] text-[#e6e6e6] whitespace-pre-wrap break-words">
+                    <code>{scriptCode}</code>
+                </pre>
+            </div>
+
+            <div
+                className={`min-h-[360px] max-h-[700px] overflow-y-auto p-8 flex-1 h-full min-h-full ${activeTab === 'preview' ? '' : 'hidden'}`}
+            >
+                {!canCopy ? (
+                    <IntegrationsPreview current={currentPair} />
+                ) : (
+                    <div ref={previewRef} className="min-h-[300px]" />
+                )}
+            </div>
+        </div>
     );
 }

--- a/src/app/components/integrations-script/ScriptPicker.js
+++ b/src/app/components/integrations-script/ScriptPicker.js
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { Search, Check, X } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Plus, Search, Check, X } from 'lucide-react';
 
 const MAX_FEATURE = 10;
 const INITIAL_VISIBLE = 36;
@@ -19,13 +19,13 @@ export default function ScriptPicker({
 }) {
     const filledCount = slots.filter(Boolean).length;
     const lastFilledFeature = slots.slice(1).reduce((acc, s, i) => (s ? i : acc), -1);
-    const visibleFeatureCount = Math.min(MAX_FEATURE, Math.max(2, lastFilledFeature + 2));
+    const visibleFeatureCount = slots[0] ? Math.min(MAX_FEATURE, lastFilledFeature + 2) : 0;
     const [showAll, setShowAll] = useState(false);
     const visibleApps = query || showAll ? apps : apps.slice(0, INITIAL_VISIBLE);
     const hasMore = !query && !showAll && apps.length > INITIAL_VISIBLE;
 
     return (
-        <div className="overflow-hidden rounded-[14px] border border-[#ece9df] bg-[#faf9f4]">
+        <div className="flex flex-col overflow-hidden rounded-lg border border-[#ece9df] bg-[#faf9f4] h-full">
             <div className="flex flex-col gap-4 border-b border-[#ece9df] p-4">
                 <div className="flex items-center justify-between">
                     <span className="text-[12px] font-semibold uppercase tracking-[0.6px] text-[#8a8a8a]">
@@ -43,23 +43,30 @@ export default function ScriptPicker({
                     )}
                 </div>
                 <div className="flex flex-wrap gap-3">
-                    <SlotCard
-                        label="My app"
-                        slot={slots[0]}
-                        isPrimary
-                        emptyLabel="Select"
-                        onRemove={() => onRemoveSlot(0)}
-                    />
-                    {Array.from({ length: visibleFeatureCount }).map((_, i) => (
-                        <SlotCard
-                            key={`feat-${i}`}
-                            label={`appName${i + 1}`}
-                            slot={slots[i + 1]}
-                            emptyLabel="Add app"
-                            onRemove={() => onRemoveSlot(i + 1)}
-                        />
-                    ))}
-                    {visibleFeatureCount < MAX_FEATURE && <AddMoreCard />}
+                    {(() => {
+                        const nextEmptyIdx = slots.findIndex((s, i) => i > 0 && !s);
+                        return (
+                            <>
+                                <SlotCard
+                                    label="My app"
+                                    slot={slots[0]}
+                                    isPrimary={!slots[0]}
+                                    emptyLabel="Select"
+                                    onRemove={() => onRemoveSlot(0)}
+                                />
+                                {Array.from({ length: visibleFeatureCount }).map((_, i) => (
+                                    <SlotCard
+                                        key={`feat-${i}`}
+                                        label={`appName${i + 1}`}
+                                        slot={slots[i + 1]}
+                                        isPrimary={slots[0] && i + 1 === nextEmptyIdx}
+                                        emptyLabel="Add app"
+                                        onRemove={() => onRemoveSlot(i + 1)}
+                                    />
+                                ))}
+                            </>
+                        );
+                    })()}
                 </div>
                 <div className="relative w-full">
                     <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8a8a8a]" />
@@ -98,19 +105,25 @@ export default function ScriptPicker({
             </div>
 
             <div
-                className={`grid grid-cols-2 gap-2 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 ${
-                    showAll || query ? '' : 'max-h-[320px] overflow-y-auto'
-                }`}
+                className="grid auto-rows-min grid-cols-2 gap-2 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 max-h-[480px] overflow-y-auto "
             >
                 {loading && apps.length === 0 ? (
-                    Array.from({ length: 12 }).map((_, i) => (
+                    Array.from({ length: 6 }).map((_, i) => (
                         <div
                             key={i}
-                            className="h-[64px] animate-pulse rounded-md border border-[#ece9df] bg-white"
+                            className="h-[40px] animate-pulse rounded-md border border-[#ece9df] bg-[#faf9f4]"
                         />
                     ))
                 ) : apps.length === 0 ? (
-                    <div className="col-span-full py-6 text-center text-[14px] text-[#8a8a8a]">No apps found.</div>
+                    <>
+                        {Array.from({ length: 6 }).map((_, i) => (
+                            <div
+                                key={i}
+                                className="h-[40px] rounded-md border border-dashed border-[#ece9df] bg-[#faf9f4]"
+                            />
+                        ))}
+                        <div className="col-span-full py-2 text-center text-[13px] text-[#8a8a8a]">No apps found.</div>
+                    </>
                 ) : (
                     visibleApps.map((app) => {
                         const selected = selectedSlugs.has(app.appslugname);
@@ -122,9 +135,8 @@ export default function ScriptPicker({
                                 type="button"
                                 disabled={disabled}
                                 onClick={() => onSelectApp(app)}
-                                className={`flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-left transition ${
-                                    selected ? 'border-accent' : 'border-[#ece9df] hover:border-accent'
-                                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                                className={`flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-left transition ${selected ? 'border-accent' : 'border-[#ece9df] hover:border-accent'
+                                    } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
                             >
                                 <img
                                     src={app.iconurl || 'https://placehold.co/36x36'}
@@ -149,7 +161,7 @@ function SlotCard({ slot, label, isPrimary, emptyLabel, onRemove }) {
         <div
             className={`flex min-w-[150px] flex-col justify-between gap-2 rounded-lg border bg-white p-3 ${borderColor}`}
         >
-            <span className={`font-mono text-sm font-semibold tracking-[0.2px] ${labelColor}`}>{label}</span>
+            <span className={`text-xs font-semibold ${labelColor}`}>{label}</span>
             {slot ? (
                 <div className="flex items-center justify-between gap-2">
                     <div className="flex min-w-0 items-center gap-2">
@@ -158,7 +170,7 @@ function SlotCard({ slot, label, isPrimary, emptyLabel, onRemove }) {
                             alt={slot.name}
                             className="h-6 w-6 flex-shrink-0 rounded-[6px] object-contain"
                         />
-                        <span className="truncate text-[13px] font-semibold text-[#1a1a1a]">{slot.name}</span>
+                        <span className="truncate text-[10px] font-semibold text-[#1a1a1a]">{slot.name}</span>
                     </div>
                     <button
                         type="button"
@@ -181,10 +193,17 @@ function SlotCard({ slot, label, isPrimary, emptyLabel, onRemove }) {
     );
 }
 
-function AddMoreCard() {
+function AddMoreCard({ onClick }) {
     return (
-        <div className="flex h-[78px] w-[170px] items-center justify-center rounded-[12px] border border-dashed border-[#cfcabb] bg-transparent text-[13px] font-semibold text-[#5a5a5a]">
-            <span className="mr-1.5 text-[16px] leading-none">+</span> Add app
-        </div>
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex min-w-[150px] items-center gap-2 rounded-lg border border-dashed border-[#cfcabb] bg-transparent p-3 text-[13px] font-semibold text-[#5a5a5a] transition hover:border-accent hover:text-accent"
+        >
+            <span className="flex h-6 w-6 items-center justify-center rounded-[6px] border border-dashed border-[#cfcabb] text-[#8a8a8a]">
+                <Plus className="h-3.5 w-3.5" />
+            </span>
+            Add more
+        </button>
     );
 }

--- a/src/app/components/integrations-script/SetupBuilder.js
+++ b/src/app/components/integrations-script/SetupBuilder.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import searchApps from '@/utils/searchApps';
 import ScriptPicker from './ScriptPicker';
 import ScriptOutput from './ScriptOutput';
@@ -9,12 +10,46 @@ const MAX_FEATURE = 10;
 const TOTAL_SLOTS = MAX_FEATURE + 1; // 1 primary + 10 feature
 
 export default function SetupBuilder({ initialApps = [] }) {
+    const searchParams = useSearchParams();
+    const preselectSlug = searchParams?.get('app') || '';
     const [query, setQuery] = useState('');
     const [apps, setApps] = useState(initialApps);
     const [loading, setLoading] = useState(false);
     const [slots, setSlots] = useState(Array(TOTAL_SLOTS).fill(null)); // index 0 = primary
     const [copied, setCopied] = useState(false);
     const debounceRef = useRef(null);
+    const preselectDoneRef = useRef(false);
+
+    useEffect(() => {
+        if (!preselectSlug || preselectDoneRef.current) return;
+        let cancelled = false;
+        const applyPreselect = (app) => {
+            if (!app || cancelled) return;
+            preselectDoneRef.current = true;
+            setSlots((prev) => {
+                if (prev[0]) return prev;
+                const next = [...prev];
+                next[0] = app;
+                return next;
+            });
+            setApps((prev) => (prev.some((a) => a.appslugname === app.appslugname) ? prev : [app, ...prev]));
+        };
+        const local = initialApps.find((a) => a.appslugname === preselectSlug);
+        if (local) {
+            applyPreselect(local);
+            return;
+        }
+        (async () => {
+            try {
+                const res = await searchApps(preselectSlug);
+                const match = Array.isArray(res) ? res.find((a) => a.appslugname === preselectSlug) : null;
+                applyPreselect(match);
+            } catch { }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [preselectSlug, initialApps]);
 
     useEffect(() => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -94,46 +129,47 @@ export default function SetupBuilder({ initialApps = [] }) {
             await navigator.clipboard.writeText(scriptCode);
             setCopied(true);
             setTimeout(() => setCopied(false), 1800);
-        } catch {}
+        } catch { }
     };
 
     return (
         <div className="container my-20" id="setup">
             <div className="rounded-lg border border-[#e2dfd2] bg-white p-6 md:p-12">
-                <div className="max-w-[660px]">
-                    <span className="mb-[14px] block text-[12px] font-semibold uppercase tracking-[1.4px] text-accent">
-                        Build your script
-                    </span>
-                    <h2 className="h2">
-                        Generate your script in seconds
-                    </h2>
-                    <p className="mt-[14px] text-[16px] font-normal leading-[1.6] text-[#5a5a5a] md:text-[18px]">
-                        Pick your app and the tools you want to feature. The script fills itself in automatically, ready
-                        to copy and paste anywhere.
-                    </p>
+                <div className="flex items-start justify-between gap-6">
+                    <div className="max-w-[660px]">
+                        <span className="mb-[14px] block text-[12px] font-semibold uppercase tracking-[1.4px] text-accent">
+                            Build your script
+                        </span>
+                        <h2 className="h1">Generate your script in seconds</h2>
+                        <p>
+                            Pick your app and the tools you want to feature. The script fills itself in automatically,
+                            ready to copy and paste anywhere.
+                        </p>
+                    </div>
+                    <a href="#how" className="btn btn-outline flex-shrink-0">
+                        See how it works
+                    </a>
                 </div>
 
-                <div className="mt-10 grid gap-6">
-                    <ScriptPicker
-                        slots={slots}
-                        query={query}
-                        setQuery={setQuery}
-                        apps={apps}
-                        loading={loading}
-                        selectedSlugs={selectedSlugs}
-                        onSelectApp={handleSelect}
-                        onRemoveSlot={removeSlot}
-                        onClearAll={() => setSlots(Array(TOTAL_SLOTS).fill(null))}
-                    />
-                    <ScriptOutput
-                        scriptCode={scriptCode}
-                        canCopy={canCopy}
-                        copied={copied}
-                        onCopy={handleCopy}
-                    />
+                <div className="mt-10 grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div className="w-full min-w-0">
+                        <ScriptPicker
+                            slots={slots}
+                            query={query}
+                            setQuery={setQuery}
+                            apps={apps}
+                            loading={loading}
+                            selectedSlugs={selectedSlugs}
+                            onSelectApp={handleSelect}
+                            onRemoveSlot={removeSlot}
+                            onClearAll={() => setSlots(Array(TOTAL_SLOTS).fill(null))}
+                        />
+                    </div>
+                    <div className="w-full min-w-0">
+                        <ScriptOutput scriptCode={scriptCode} canCopy={canCopy} copied={copied} onCopy={handleCopy} />
+                    </div>
                 </div>
             </div>
         </div>
     );
 }
-

--- a/src/app/components/integrations-script/WhyItMatters.js
+++ b/src/app/components/integrations-script/WhyItMatters.js
@@ -56,7 +56,7 @@ export default function WhyItMatters() {
 
 function CompareCard({ pillLabel, pillClass, title, iconBg, iconColor, Icon, points, headerBg }) {
     return (
-        <div className="overflow-hidden rounded-[14px] border border-[#e2dfd2] bg-white">
+        <div className="overflow-hidden rounded-lg border border-[#e2dfd2] bg-white">
             <div className={`flex items-center gap-3 px-5 py-4 ${headerBg}`}>
                 <span
                     className={`inline-flex items-center rounded-full px-2.5 py-1 text-[10.5px] font-bold uppercase tracking-[1px] ${pillClass}`}

--- a/src/app/embed/actions-via-webhook/WebhookFeatureHighlights.js
+++ b/src/app/embed/actions-via-webhook/WebhookFeatureHighlights.js
@@ -56,7 +56,7 @@ export default function WebhookFeatureHighlights({ appCount }) {
                                     className="text-white relative z-10 animate-feat-spark-float drop-shadow-sm"
                                 />
                             </div>
-                            <div className="absolute inset-[-6px] rounded-[14px] bg-[radial-gradient(circle,rgba(13,148,136,.35)_0%,transparent_70%)] animate-feat-spark-halo pointer-events-none z-0" />
+                            <div className="absolute inset-[-6px] rounded-lg bg-[radial-gradient(circle,rgba(13,148,136,.35)_0%,transparent_70%)] animate-feat-spark-halo pointer-events-none z-0" />
                         </div>
                         <div className="w-[30px] h-[6px] bg-[linear-gradient(90deg,#5eead4_0%,#5eead4_50%,transparent_50%,transparent_100%)] bg-[length:6px_2px] bg-repeat-x bg-[position:0_50%] animate-feat-connector-flow flex-shrink-0" />
                         <div className="flex-1 bg-white border border-[#bfdbfe] p-4 rounded flex flex-col gap-1">

--- a/src/app/embed/app-integration/WhyFeatures.js
+++ b/src/app/embed/app-integration/WhyFeatures.js
@@ -51,7 +51,7 @@ export default function WhyFeatures({ appCount }) {
 
                     <div className="mt-auto flex items-center gap-4 pt-8">
                         <div className="w-[54px] h-[54px] bg-gradient-to-br from-[#059669] via-[#10b981] to-[#34d399] flex items-center justify-center shrink-0 rounded-[10px] relative animate-feat-spark-glow">
-                            <div className="absolute -inset-1.5 rounded-[14px] bg-[radial-gradient(circle,rgba(5,150,105,0.35)_0%,transparent_70%)] z-0 animate-feat-spark-halo pointer-events-none" />
+                            <div className="absolute -inset-1.5 rounded-lg bg-[radial-gradient(circle,rgba(5,150,105,0.35)_0%,transparent_70%)] z-0 animate-feat-spark-halo pointer-events-none" />
                             <FileText
                                 className="w-7 h-7 text-white relative z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.18)] animate-feat-spark-float"
                                 strokeWidth={2}

--- a/src/app/integrations-script/page.js
+++ b/src/app/integrations-script/page.js
@@ -50,7 +50,7 @@ export default async function IntegrationsScriptPage() {
                 <NavbarServer navbarData={navbarData} utm={'/integrations-script'} />
             </ConditionalNavbar>
             <div className="global-top-space">
-                <HeroSection appCount={appCount} />
+                {/* <HeroSection appCount={appCount} /> */}
                 <SetupBuilder initialApps={apps} />
                 <WhyItMatters />
                 <HowItWorks />

--- a/src/app/lifetime-deal/Comparison.js
+++ b/src/app/lifetime-deal/Comparison.js
@@ -89,7 +89,7 @@ export default function Comparison() {
                         {COMPETITORS.map((c) => (
                             <div
                                 key={c.name}
-                                className="bg-[#E5E5E5] rounded-[14px] p-5 flex items-center justify-between transition-all duration-300 hover:-translate-y-0.5"
+                                className="bg-[#E5E5E5] rounded-lg p-5 flex items-center justify-between transition-all duration-300 hover:-translate-y-0.5"
                             >
                                 <div>
                                     <div className="text-lg font-bold tracking-[-0.3px] text-gray-900 mb-1">

--- a/src/app/pricing/page.js
+++ b/src/app/pricing/page.js
@@ -39,11 +39,11 @@ export default async function PricingPage() {
 
     return (
         <>
-            <MetaHeadComp metaData={metaData} page={'/pricing'} />
-            <ConditionalNavbar>
-                <NavbarServer navbarData={navbarData} utm={'/pricing'} />
-            </ConditionalNavbar>
-            <div className="container cont pb-4 pt-12 lg:gap-20 md:gap-16 gap-12 global-top-space">
+            <div className="container cont pb-4 lg:gap-20 md:gap-16 gap-12 global-top-space">
+                <MetaHeadComp metaData={metaData} page={'/pricing'} />
+                <ConditionalNavbar>
+                    <NavbarServer navbarData={navbarData} utm={'/pricing'} />
+                </ConditionalNavbar>
                 <div className="cont flex flex-col items-center text-center gap-6">
                     <div className="flex flex-col items-center">
                         <h1 className="text-6xl">

--- a/src/components/agencyPartner/WhyAgenciesSection.js
+++ b/src/components/agencyPartner/WhyAgenciesSection.js
@@ -62,7 +62,7 @@ export default function WhyAgenciesSection() {
                                     border-gray-200
                                 `}
                             >
-                                <div className="w-16 h-16 rounded-[14px] flex items-center justify-center mb-5 transition-colors duration-200 group-hover:bg-[#a8200d]/[0.07]">
+                                <div className="w-16 h-16 rounded-lg flex items-center justify-center mb-5 transition-colors duration-200 group-hover:bg-[#a8200d]/[0.07]">
                                     {card.icon}
                                 </div>
                                 <h3
@@ -93,7 +93,7 @@ export default function WhyAgenciesSection() {
                                     border-gray-200
                                 `}
                             >
-                                <div className="w-16 h-16 rounded-[14px] flex items-center justify-center mb-5 transition-colors duration-200 group-hover:bg-[#a8200d]/[0.07]">
+                                <div className="w-16 h-16 rounded-lg flex items-center justify-center mb-5 transition-colors duration-200 group-hover:bg-[#a8200d]/[0.07]">
                                     {card.icon}
                                 </div>
                                 <h3

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -304,3 +304,8 @@
 #interfaceEmbed {
     display: none !important;
 }
+
+// viasocket integrations preview override
+.container-viasocket-integrations {
+    margin: 0 !important;
+}


### PR DESCRIPTION
…ed preview/code view to ScriptOutput

- Replace browser mockup in IntegrationsPreview with clean template card grid layout
- Update template text to use actual workflow descriptions (e.g., "Send Message to {{app}} when New Records Appear in YourApp")
- Add AppIcon component to display app logos or placeholder icons in template cards
- Replace "Use template" button with "Try it" link in template cards
- Remove floating code widget || 1