### PR TITLE
Update "Hire an expert" text to "Let us build" across navigation and …

### DIFF
--- a/src/app/components/navbar/MainNavbar.js
+++ b/src/app/components/navbar/MainNavbar.js
@@ -17,6 +17,15 @@ export default function MainNavbar({
 }) {
     const pathname = usePathname();
 
+    const getMcpUtmSource = () => {
+        if (!pathname?.startsWith('/mcp/')) return undefined;
+        const segments = pathname.split('/').filter(Boolean);
+        if (segments.length >= 2 && segments[1] !== 'category') {
+            return segments[1];
+        }
+        return undefined;
+    };
+
     const isActive = (path) => {
         if (!path || path.startsWith('http')) return '';
         const currentPath = pathname.split('?')[0].split('#')[0];
@@ -84,7 +93,7 @@ export default function MainNavbar({
                                         ? 'https://app.mushroom.viasocket.com/login?'
                                         : 'https://flow.viasocket.com?',
                                     null,
-                                    pathname?.startsWith('/mcp') ? 'viasocket' : undefined
+                                    pathname?.startsWith('/mcp') ? getMcpUtmSource() || 'viasocket' : undefined
                                 )
                             }
                             rel="nofollow"
@@ -99,7 +108,7 @@ export default function MainNavbar({
                                     e,
                                     pathname?.startsWith('/mcp') ? 'https://app.mushroom.viasocket.com/login?' : '/signup?',
                                     null,
-                                    pathname?.startsWith('/mcp') ? 'viasocket' : undefined
+                                    pathname?.startsWith('/mcp') ? getMcpUtmSource() || 'viasocket' : undefined
                                 )
                             }
                         >

--- a/src/app/components/navbar/TopNavLinks.js
+++ b/src/app/components/navbar/TopNavLinks.js
@@ -23,7 +23,7 @@ export default function TopNavLinks({ borderClass = '', backgroundClass = '', ut
                 <div
                     className={`${style.nav_btn} ${borderClass} ${backgroundClass} hidden border-l border-gray-300 lg:flex w-fit ${MCPPadding} !h-[30px] items-center justify-center cursor-pointer hover:text-accent !text-xs text-nowrap`}
                 >
-                    Hire an expert
+                    Let us build
                 </div>
             </Link>
             <Link href={'/support'}>

--- a/src/app/hire-an-expert/Comparison.js
+++ b/src/app/hire-an-expert/Comparison.js
@@ -49,7 +49,7 @@ export default function Comparison({ onHire }) {
                         onClick={onHire}
                         className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a1a1a] hover:bg-black text-white text-sm font-semibold rounded-full transition-colors group"
                     >
-                        Hire an expert
+                        Let us build
                         <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                     </button>
                 </div>

--- a/src/app/hire-an-expert/ReadyToAutomate.js
+++ b/src/app/hire-an-expert/ReadyToAutomate.js
@@ -63,7 +63,7 @@ export default function ReadyToAutomate({ onHire }) {
             </div>
 
             <button onClick={onHire} className="btn btn-accent group">
-                Hire an Expert
+                Let us build
                 <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
             </button>
         </section>

--- a/src/app/hire-an-expert/hire-expert.scss
+++ b/src/app/hire-an-expert/hire-expert.scss
@@ -1,4 +1,4 @@
-/* Shared styles for the Hire an Expert section */
+/* Shared styles for the Let us build section */
 
 /* HeroHub animations */
 @keyframes hireFloat {

--- a/src/components/indexComps/indexBannerComp/indexBannerComp.js
+++ b/src/components/indexComps/indexBannerComp/indexBannerComp.js
@@ -61,7 +61,7 @@ export default function IndexBannerComp() {
                             target="_blank"
                             className="text-accent text-xs flex items-center gap-1"
                         >
-                            Hire an Expert <ArrowUpRight className="w-4 h-4" />
+                            Let us build <ArrowUpRight className="w-4 h-4" />
                         </Link>
                     </div>
                 </div>

--- a/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
+++ b/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
@@ -149,7 +149,14 @@ export default function McpAppClientComp({
                                 {mcpPromptData[0]?.prompt || appOneDetails.events.length > 0 ? (
                                     <button
                                         className="btn btn-accent"
-                                        onClick={(e) => handleRedirect(e, 'https://app.mushroom.viasocket.com/login?')}
+                                        onClick={(e) =>
+                                            handleRedirect(
+                                                e,
+                                                'https://app.mushroom.viasocket.com/login?',
+                                                null,
+                                                appOneDetails?.appslugname || appOneDetails?.name
+                                            )
+                                        }
                                     >
                                         Get Your MCP URL
                                     </button>

--- a/src/components/navbar/menubar.js
+++ b/src/components/navbar/menubar.js
@@ -28,7 +28,7 @@ function NavList({ navItems }) {
             </li>
             <li className="hover:bg-gray-100 text-black p-2">
                 <Link href="https://cal.id/team/viasocket/hire-an-expert" target="_blank" rel="nofollow noopener noreferrer" className="flex flex-col">
-                    <span className="text-lg hover:text-accent hover:underline">Hire an expert</span>
+                    <span className="text-lg hover:text-accent hover:underline">Let us build</span>
                 </Link>
             </li>
         </ul>


### PR DESCRIPTION
…hire-expert pages, and enhance MCP UTM source tracking

- Replace "Hire an expert" with "Let us build" in TopNavLinks, mobile menubar, IndexBannerComp, Comparison, and ReadyToAutomate components
- Update hire-expert.scss comment to reflect new terminology
- Add getMcpUtmSource() function to MainNavbar to extract app slug from MCP URLs for UTM tracking
- Update Dashboard and Login/Sign Up button onClick handlers to use dynamic M || 1