### PR TITLE
Add Similar Apps internal-linking sidebar + hero/popular-flows polish

### DIFF
--- a/src/app/components/integrations/IntegrationsMain.js
+++ b/src/app/components/integrations/IntegrationsMain.js
@@ -19,6 +19,8 @@ const IntegrationsMain = (props) => {
                     blogsData={data.blogData}
                     appOneDetails={data.appOneDetails}
                     appTwoDetails={data.appTwoDetails}
+                    similarAppsOne={data.similarAppsOne}
+                    similarAppsTwo={data.similarAppsTwo}
                     combosData={data.combosData}
                     footerData={data.footerData}
                     videoData={data.videoData}

--- a/src/app/lib/integration-data.js
+++ b/src/app/lib/integration-data.js
@@ -27,6 +27,17 @@ function safeJsonParse(value, fallback = []) {
     try { return JSON.parse(value) || fallback; } catch { return fallback; }
 }
 
+async function getSimilarApps(appDetails, excludeSlugs, pageUrl) {
+    const primaryCategory = appDetails?.category?.[0];
+    if (!primaryCategory) return [];
+
+    const apps = await getApps({ categoryData: [{ name: primaryCategory }], limit: 12 }, pageUrl);
+
+    return (apps || [])
+        .filter((app) => app?.appslugname && !excludeSlugs.includes(app.appslugname))
+        .slice(0, 9);
+}
+
 function transformAppData(app) {
     return {
         appSlug: app.app_slug,
@@ -84,10 +95,13 @@ export async function getIntegrationsPageData(slug = [], searchParams = {}) {
             const appTwoDetails = getAppDetails(combosData, integrationsInfo?.apptwo);
 
             if (appOneDetails && appTwoDetails) {
-                const [blogData, videoData, templateData] = await Promise.all([
+                const excludeSlugs = [appOneDetails?.appslugname, appTwoDetails?.appslugname];
+                const [blogData, videoData, templateData, similarAppsOne, similarAppsTwo] = await Promise.all([
                     getBlogData({ tag1: appOneDetails?.appslugname, tag2: appTwoDetails?.appslugname }, pageUrl),
                     getVideoData({ tag1: appOneDetails?.appslugname, tag2: appTwoDetails?.appslugname }, pageUrl),
                     getTemplates(pageUrl),
+                    getSimilarApps(appOneDetails, excludeSlugs, pageUrl),
+                    getSimilarApps(appTwoDetails, excludeSlugs, pageUrl),
                 ]);
 
                 const validTemplates = templateData.filter(
@@ -104,6 +118,8 @@ export async function getIntegrationsPageData(slug = [], searchParams = {}) {
                     combosData: combosData || {},
                     appOneDetails: appOneDetails || {},
                     appTwoDetails: appTwoDetails || {},
+                    similarAppsOne: similarAppsOne || [],
+                    similarAppsTwo: similarAppsTwo || [],
                     categoryData: {},
                     blogData: blogData || [],
                     videoData: videoData || [],

--- a/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
+++ b/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
@@ -74,17 +74,18 @@ export default function IntegrationsIndexClientComp({
                 if (!fetchedApps) {
                     setSearchedApps([]);
                 } else {
+                    const searchTermLower = searchTerm.toLowerCase();
                     const sortedApps = fetchedApps.sort((a, b) => {
                         const aName = a?.name?.toLowerCase() || '';
                         const bName = b?.name?.toLowerCase() || '';
 
-                        const aStarts = aName.startsWith(searchTerm);
-                        const bStarts = bName.startsWith(searchTerm);
+                        const aStarts = aName.startsWith(searchTermLower);
+                        const bStarts = bName.startsWith(searchTermLower);
 
                         if (aStarts !== bStarts) return aStarts ? -1 : 1;
 
-                        const aContains = aName.includes(searchTerm);
-                        const bContains = bName.includes(searchTerm);
+                        const aContains = aName.includes(searchTermLower);
+                        const bContains = bName.includes(searchTermLower);
 
                         if (aContains !== bContains) return aContains ? -1 : 1;
 
@@ -252,21 +253,22 @@ export default function IntegrationsIndexClientComp({
                                         );
                                     })}
                                     <div
-                                        className={`${style.app} border-2 hover-bg-grey-100-text-black border-dashed custom-border flex justify-center`}
+                                        className={`${style.app} border-2 hover-bg-grey-100-text-black border-dashed custom-border flex justify-center relative w-[130%] !py-3 sm:!py-4`}
                                     >
-                                        <div className="flex items-center gap-2 justify-between">
-                                            <h2 className="flex items-center gap-2">
+                                        <div className="flex items-center gap-3 justify-between w-full">
+                                            <div className="flex items-start gap-3">
                                                 <span className="text-xl">
                                                     <span aria-label="lightbulb">💡</span>
                                                 </span>
-                                                <span>Request an App</span>
-                                            </h2>
+                                                <div className="flex flex-col gap-1">
+                                                    <h2>Request an App</h2>
+                                                    <span className="w-fit inline-flex items-center px-3 py-0.5 rounded-full text-xs font-semibold bg-green-50 border border-green-200 text-green-700">
+                                                        Added in 2 days
+                                                    </span>
+                                                </div>
+                                            </div>
                                             <RequestIntegrationPopupOpener showType="button" title="Request" />
                                         </div>
-                                        <p className={`${style?.app__des}`}>
-                                            Can’t find the App you’re looking for? We’ll try to build it for you within
-                                            48 hours
-                                        </p>
                                     </div>
                                 </>
                             ) : (
@@ -349,21 +351,23 @@ export function AppVisual({ app, index, redirectPart }) {
         </Link>
     ) : (
         <div
-            className={`${style.app} border-2 hover-bg-grey-100-text-black border-dashed custom-border flex justify-center`}
+            className={`${style.app} border-2 hover-bg-grey-100-text-black border-dashed custom-border flex justify-center relative w-[130%] !py-3 sm:!py-4`}
         >
-            <div className="flex items-center gap-2 justify-between">
-                <h2 className="flex items-center gap-2">
+            <div className="flex items-center gap-3 justify-between w-full">
+                <div className="flex items-start gap-3">
                     <span className="text-xl">
                         <span aria-label="lightbulb">💡</span>
                     </span>
-                    <span>Request an App</span>
-                </h2>
+                    <div className="flex flex-col gap-1">
+                        <h2>Request an App</h2>
+                        <span className="w-fit inline-flex items-center px-3 py-0.5 rounded-full text-xs font-semibold bg-green-50 border border-green-200 text-green-700">
+                            Added in 2 days
+                        </span>
+                    </div>
+                </div>
 
                 <RequestIntegrationPopupOpener showType="button" title="Request" />
             </div>
-            <p className={`${style?.app__des}`}>
-                Can’t find the App you’re looking for? We’ll try to build it for you within 48 hours
-            </p>
         </div>
     );
 }

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/AIFeatureSection.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/AIFeatureSection.js
@@ -7,7 +7,7 @@ export default function AIFeatureSection({ appOneName, appTwoName }) {
 
     return (
         <div className="container">
-            <div className="flex flex-col md:flex-row items-stretch gap-10 md:gap-16">
+            <div className="flex flex-col md:flex-row items-stretch justify-around gap-10 md:gap-16">
                 {/* Left: product screenshot (dark app UI image) */}
                 <div className="w-full md:w-[38%] shrink-0 rounded-xl overflow-hidden">
                     <Image

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/AboutApps.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/AboutApps.js
@@ -1,94 +1,155 @@
 'use client';
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { ChevronDown } from 'lucide-react';
 import ExternalLink from '@/utils/ExternalLink';
 import { LinkText } from '@/components/uiComponents/buttons';
 import createURL from '@/utils/createURL';
+import Breadcrumb from '@/components/breadcrumb/breadcrumb';
 
-export default function AboutApps({ appOneDetails, appTwoDetails, getDoFollowUrlStatusArray }) {
+const SIMILAR_APPS_PAGE_SIZE = 3;
+
+function SimilarAppsSidebar({ appDetails, similarApps }) {
+    const [visibleCount, setVisibleCount] = useState(SIMILAR_APPS_PAGE_SIZE);
+
+    if (!similarApps?.length) return null;
+
+    const visibleApps = similarApps.slice(0, visibleCount);
+    const hasMore = visibleCount < similarApps.length;
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <div className="flex items-center gap-3">
+                <span
+                    className="w-1 h-[22px] rounded-full shrink-0 bg-accent"
+                    aria-hidden="true"
+                ></span>
+                <h4 className="font-bold text-black text-xl">Similar apps</h4>
+            </div>
+            <div className="flex flex-col gap-2">
+                {visibleApps.map((app, index) => (
+                    <Link
+                        key={index}
+                        href={createURL(`/integrations/${appDetails?.appslugname}/${app?.appslugname}`)}
+                        className="flex items-center gap-3 p-3 border custom-border rounded-xl bg-white hover:border-accent hover:bg-accent/5 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-colors w-full"
+                    >
+                        <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
+                            <Image
+                                src={app?.iconurl || 'https://placehold.co/32x32'}
+                                width={24}
+                                height={24}
+                                alt={`${app?.name} logo`}
+                                className="w-6 h-6 object-contain"
+                            />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <span className="block text-sm font-semibold text-gray-900 truncate">{app?.name}</span>
+                            {app?.category?.length > 0 && (
+                                <span className="block text-xs text-gray-500 truncate">
+                                    {app.category.slice(0, 2).join(', ')}
+                                </span>
+                            )}
+                        </div>
+                    </Link>
+                ))}
+            </div>
+            {hasMore && (
+                <button
+                    type="button"
+                    onClick={() => setVisibleCount((count) => count + SIMILAR_APPS_PAGE_SIZE)}
+                    className="btn btn-outline custom-border w-full justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                >
+                    Load More <ChevronDown className="w-5 h-5" />
+                </button>
+            )}
+        </div>
+    );
+}
+
+function AppRow({ appDetails, otherApp, similarApps, getDoFollowUrlStatusArray }) {
+    return (
+        <div className="flex flex-col p-6 md:p-12 border custom-border rounded-2xl bg-white">
+            <div className="text-xs sm:text-sm text-gray-600 mb-4">
+                <Breadcrumb
+                    parent="Integrations"
+                    child1={appDetails?.name}
+                    child2={`${appDetails?.name} + ${otherApp?.name}`}
+                    parentLink="/integrations"
+                    child1Link={`/integrations/${appDetails?.appslugname}`}
+                />
+            </div>
+            <div className="flex flex-col md:flex-row md:items-start gap-8">
+                <div className="cont gap-4 md:flex-1 min-w-0">
+                    <div className="cont gap-2">
+                        <div className="w-14 h-14 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
+                            <Image
+                                src={appDetails?.iconurl || 'https://placehold.co/36x36'}
+                                width={32}
+                                height={32}
+                                alt={`${appDetails?.name} logo`}
+                                className="w-8 h-8 object-contain"
+                            />
+                        </div>
+                        <h3 className="h3 font-bold pt-5">About {appDetails?.name}</h3>
+                    </div>
+                    <p className="max-w-2xl">{appDetails?.description}</p>
+                    <div className="flex flex-wrap gap-2">
+                        {appDetails?.category?.slice(0, 2).map((cat, index) => (
+                            <Link
+                                key={index}
+                                href={createURL(`/integrations/category/${cat.toLowerCase().replace(/\s+/g, '-')}`)}
+                                className="mb-2"
+                            >
+                                <span className="btn btn-outline">{cat}</span>
+                            </Link>
+                        ))}
+                    </div>
+                    <ExternalLink
+                        href={(() => {
+                            const baseUrl = appDetails?.domain?.startsWith('http')
+                                ? appDetails?.domain
+                                : 'http://' + appDetails?.domain;
+                            const separator = baseUrl.includes('?') ? '&' : '?';
+                            return `${baseUrl}${separator}utm_source=viasocket`;
+                        })()}
+                        appSlugName={appDetails?.appslugname}
+                        doFollowArray={getDoFollowUrlStatusArray}
+                    >
+                        <LinkText children={'Learn more'} />
+                    </ExternalLink>
+                </div>
+
+                <div className="md:w-[340px] md:shrink-0 md:ml-auto">
+                    <SimilarAppsSidebar appDetails={appDetails} similarApps={similarApps} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function AboutApps({
+    appOneDetails,
+    appTwoDetails,
+    similarAppsOne,
+    similarAppsTwo,
+    getDoFollowUrlStatusArray,
+}) {
     return (
         <div className="container pb-4">
-            <div className="cont">
-                <div className="flex flex-col md:flex-row border border-x-0 custom-border bg-white">
-                    <div className="cont gap-4 w-full p-6 md:p-12 border border-t-0 md:border-b-0 custom-border">
-                        <div className="cont gap-2">
-                            <Image
-                                className="h-10 w-fit"
-                                src={appOneDetails?.iconurl || 'https://placehold.co/36x36'}
-                                width={36}
-                                height={36}
-                                alt={`${appOneDetails?.name} logo`}
-                            />
-                            <h3 className="h3 font-bold pt-5">About {appOneDetails?.name}</h3>
-                        </div>
-                        <p className="text-sm sm:text-lg text-black h-full">{appOneDetails?.description}</p>
-                        <div className="flex flex-wrap gap-2">
-                            {appOneDetails?.category?.slice(0, 2).map((cat, index) => (
-                                <Link
-                                    key={index}
-                                    href={createURL(
-                                        `/integrations/category/${cat.toLowerCase().replace(/\s+/g, '-')}`
-                                    )}
-                                    className="mb-2"
-                                >
-                                    <span className="btn btn-outline">{cat}</span>
-                                </Link>
-                            ))}
-                        </div>
-                        <ExternalLink
-                            href={(() => {
-                                const baseUrl = appOneDetails?.domain?.startsWith('http')
-                                    ? appOneDetails?.domain
-                                    : 'http://' + appOneDetails?.domain;
-                                const separator = baseUrl.includes('?') ? '&' : '?';
-                                return `${baseUrl}${separator}utm_source=viasocket`;
-                            })()}
-                            appSlugName={appOneDetails?.appslugname}
-                            doFollowArray={getDoFollowUrlStatusArray}
-                        >
-                            <LinkText children={'Learn more'} />
-                        </ExternalLink>
-                    </div>
-                    <div className="cont w-full gap-4 p-12 border-x md:border-l-0 custom-border">
-                        <div className="cont gap-2">
-                            <Image
-                                className="h-10 w-fit"
-                                src={appTwoDetails?.iconurl || 'https://placehold.co/36x36'}
-                                width={36}
-                                height={36}
-                                alt={`${appTwoDetails?.name} logo`}
-                            />
-                            <h3 className="h3 font-bold pt-5">About {appTwoDetails?.name}</h3>
-                        </div>
-                        <p className="text-sm sm:text-lg text-black h-full">{appTwoDetails?.description}</p>
-                        <div className="flex flex-wrap gap-2">
-                            {appTwoDetails?.category?.slice(0, 2).map((cat, index) => (
-                                <Link
-                                    key={index}
-                                    href={createURL(
-                                        `/integrations/category/${cat.toLowerCase().replace(/\s+/g, '-')}`
-                                    )}
-                                    className="mb-2"
-                                >
-                                    <span className="btn btn-outline">{cat}</span>
-                                </Link>
-                            ))}
-                        </div>
-                        <ExternalLink
-                            href={(() => {
-                                const baseUrl = appTwoDetails?.domain?.startsWith('http')
-                                    ? appTwoDetails?.domain
-                                    : 'http://' + appTwoDetails?.domain;
-                                const separator = baseUrl.includes('?') ? '&' : '?';
-                                return `${baseUrl}${separator}utm_source=viasocket`;
-                            })()}
-                            appSlugName={appTwoDetails?.appslugname}
-                            doFollowArray={getDoFollowUrlStatusArray}
-                        >
-                            <LinkText children={'Learn more'} />
-                        </ExternalLink>
-                    </div>
-                </div>
+            <div className="cont gap-6">
+                <AppRow
+                    appDetails={appOneDetails}
+                    otherApp={appTwoDetails}
+                    similarApps={similarAppsOne}
+                    getDoFollowUrlStatusArray={getDoFollowUrlStatusArray}
+                />
+                <AppRow
+                    appDetails={appTwoDetails}
+                    otherApp={appOneDetails}
+                    similarApps={similarAppsTwo}
+                    getDoFollowUrlStatusArray={getDoFollowUrlStatusArray}
+                />
             </div>
         </div>
     );

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/AboutApps.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/AboutApps.js
@@ -58,7 +58,7 @@ function SimilarAppsSidebar({ appDetails, similarApps }) {
                 <button
                     type="button"
                     onClick={() => setVisibleCount((count) => count + SIMILAR_APPS_PAGE_SIZE)}
-                    className="btn btn-outline custom-border w-full justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                    className="btn btn-outline fit-content ml-auto"
                 >
                     Load More <ChevronDown className="w-5 h-5" />
                 </button>
@@ -69,7 +69,7 @@ function SimilarAppsSidebar({ appDetails, similarApps }) {
 
 function AppRow({ appDetails, otherApp, similarApps, getDoFollowUrlStatusArray }) {
     return (
-        <div className="flex flex-col p-6 md:p-12 border custom-border rounded-2xl bg-white">
+        <div className="flex flex-col p-6 md:p-12 border custom-border bg-white">
             <div className="text-xs sm:text-sm text-gray-600 mb-4">
                 <Breadcrumb
                     parent="Integrations"
@@ -93,7 +93,7 @@ function AppRow({ appDetails, otherApp, similarApps, getDoFollowUrlStatusArray }
                         </div>
                         <h3 className="h3 font-bold pt-5">About {appDetails?.name}</h3>
                     </div>
-                    <p className="max-w-2xl">{appDetails?.description}</p>
+                    <p className="max-w-4xl">{appDetails?.description}</p>
                     <div className="flex flex-wrap gap-2">
                         {appDetails?.category?.slice(0, 2).map((cat, index) => (
                             <Link

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/HeroSection.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/HeroSection.js
@@ -1,5 +1,4 @@
 'use client';
-import { useState } from 'react';
 import Image from 'next/image';
 import { Plug, Sparkles, TrendingUp, ArrowRight } from 'lucide-react';
 import { handleRedirect } from '@/utils/handleRedirection';

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/HeroSection.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/HeroSection.js
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
-import { Code2, Sparkles, RefreshCcw, Zap } from 'lucide-react';
+import Image from 'next/image';
+import { Plug, Sparkles, TrendingUp, ArrowRight } from 'lucide-react';
 import { handleRedirect } from '@/utils/handleRedirection';
 
 export default function HeroSection({
@@ -17,25 +18,42 @@ export default function HeroSection({
         <div className="container">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-start justify-between">
                 <div className="cont items-start text-left gap-6">
+                    <div className="flex items-center gap-3">
+                        <Image
+                            className="h-10 w-fit"
+                            src={appOneDetails?.iconurl || 'https://placehold.co/36x36'}
+                            width={36}
+                            height={36}
+                            alt={`${appOneDetails?.name} logo`}
+                        />
+                        <ArrowRight className="w-3.5 h-3.5 text-gray-400 shrink-0" aria-hidden="true" />
+                        <Image
+                            className="h-10 w-fit"
+                            src={appTwoDetails?.iconurl || 'https://placehold.co/36x36'}
+                            width={36}
+                            height={36}
+                            alt={`${appTwoDetails?.name} logo`}
+                        />
+                    </div>
                     <h1 className="h1">
                         Connect <span className="text-accent">{appOneDetails?.name}</span> and{' '}
                         <span className="text-accent">{appTwoDetails?.name}</span>
                     </h1>
 
                     <p>
-                        Save hours every week with {appOneDetails?.name} + {appTwoDetails?.name} automations. Stop
-                        doing things manually and let viaSocket handle the repetitive tasks between your apps
+                        Integrate {appOneDetails?.name} with {appTwoDetails?.name} to automate workflows, sync data
+                        between apps, and eliminate repetitive tasks with AI-powered automation.
                     </p>
 
                     <div className="flex flex-wrap items-center gap-6 text-gray-900 text-sm font-bold">
                         <span className="flex items-center gap-1.5">
-                            <Code2 className="w-4 h-4 text-accent" /> No Code
-                        </span>
-                        <span className="flex items-center gap-1.5">
                             <Sparkles className="w-4 h-4 text-accent" /> AI Powered
                         </span>
                         <span className="flex items-center gap-1.5">
-                            <RefreshCcw className="w-4 h-4 text-accent" /> Real-time Sync
+                            <TrendingUp className="w-4 h-4 text-accent" /> Built to Scale
+                        </span>
+                        <span className="flex items-center gap-1.5">
+                            <Plug className="w-4 h-4 text-accent" /> 2000+ Integrations
                         </span>
                     </div>
 
@@ -98,28 +116,21 @@ export default function HeroSection({
                         ></div>
 
                         <div className="relative z-10">
-                            <div className="flex items-center gap-3 mb-6">
-                                <span
-                                    className="w-1.5 h-[22px] rounded-full shrink-0 bg-gradient-to-b from-accent to-accent/60"
-                                    aria-hidden="true"
-                                ></span>
-                                <h3 className="font-bold text-black text-xl">
-                                    Popular Use Cases
-                                </h3>
-                            </div>
-                            <div className="flex flex-col gap-3">
-                                {popularUseCases.slice(0, 5).map((combo, i) => (
-                                    <a
-                                        key={i}
-                                        href={getComboLink(combo)}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="group flex items-center gap-3 rounded-2xl px-[18px] py-4 relative z-10 bg-gradient-to-br from-white/70 to-white/40 border border-white/90 backdrop-blur-[32px] shadow-[0_20px_40px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.95),inset_0_0_15px_rgba(120,120,120,0.03)] hover:shadow-[0_30px_60px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.95),inset_0_0_20px_rgba(120,120,120,0.08)] transition-all duration-300 hover:-translate-y-1 hover:from-white/85 hover:to-white/60 hover:border-white/95"
-                                    >
-                                        <Zap className="w-4 h-4 text-accent shrink-0 group-hover:scale-110 transition-transform duration-300" aria-hidden="true" />
-                                        <p className="text-sm text-[#1F2430]">{combo?.description}</p>
-                                    </a>
-                                ))}
+                            <div className="flex flex-col gap-8">
+                                {popularUseCases.slice(0, 5).map((combo, i) => {
+                                    const indents = ['ml-[8%]', 'ml-0', 'ml-[14%]', 'ml-[2%]', 'ml-[10%]'];
+                                    return (
+                                        <a
+                                            key={i}
+                                            href={getComboLink(combo)}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className={`group flex items-center rounded-2xl px-[18px] py-4 relative z-10 self-start bg-gradient-to-br from-white/70 to-white/40 border border-white/90 backdrop-blur-[32px] shadow-[0_20px_40px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.95),inset_0_0_15px_rgba(120,120,120,0.03)] hover:shadow-[0_30px_60px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.95),inset_0_0_20px_rgba(120,120,120,0.08)] transition-all duration-300 hover:-translate-y-1 hover:from-white/85 hover:to-white/60 hover:border-white/95 w-fit max-w-[90%] ${indents[i % indents.length]}`}
+                                        >
+                                            <p className="text-sm text-[#1F2430]">{combo?.description}</p>
+                                        </a>
+                                    );
+                                })}
                             </div>
                         </div>
                     </div>

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
@@ -2,6 +2,7 @@
 import Image from 'next/image';
 import { ArrowRightLeft, ChevronDown, ArrowRight, ArrowDownUp } from 'lucide-react';
 import TriggerOrActionCard from './TriggerOrActionCard';
+import { handleRedirect } from '@/utils/handleRedirection';
 
 export default function PopularFlows({
     combosData,
@@ -13,7 +14,9 @@ export default function PopularFlows({
     appTwoEvents,
     openDropdown,
     setOpenDropdown,
+    selectedTrigger,
     setSelectedTrigger,
+    selectedAction,
     setSelectedAction,
     resetTrigger,
     visibleCombos,
@@ -22,6 +25,7 @@ export default function PopularFlows({
     setShowMore,
     handleSwapApps,
 }) {
+    const canBuildFlow = Boolean(selectedTrigger && selectedAction);
     const hasCombinations = combosData?.combinations?.length > 0;
 
     if (!hasCombinations) return null;
@@ -29,7 +33,6 @@ export default function PopularFlows({
     return (
         <div className="container flex flex-col gap-8">
             <div className="flex flex-col gap-3">
-                <span className="text-accent text-xs font-bold uppercase tracking-widest">Ready to use</span>
                 <h2 className="h2">
                     Popular {appOneDetails?.name} + {appTwoDetails?.name} flows
                 </h2>
@@ -81,6 +84,23 @@ export default function PopularFlows({
                         type="action"
                         resetEvent={resetTrigger}
                     />
+
+                    <button
+                        onClick={(e) => {
+                            if (!canBuildFlow) return;
+                            handleRedirect(
+                                e,
+                                `${process.env.NEXT_PUBLIC_FLOW_URL}/makeflow/trigger/${selectedTrigger.rowid}/action?events=${selectedAction.rowid}&integrations=${selectedTrigger.pluginrecordid},${selectedAction.pluginrecordid}&action&`
+                            );
+                        }}
+                        disabled={!canBuildFlow}
+                        aria-disabled={!canBuildFlow}
+                        className={`btn btn-accent px-8 py-3 md:mt-8 max-md:w-full shrink-0 whitespace-nowrap transition-opacity ${
+                            canBuildFlow ? '' : 'opacity-40 cursor-not-allowed'
+                        }`}
+                    >
+                        Build this flow
+                    </button>
                 </div>
             </div> */}
 
@@ -134,10 +154,10 @@ export default function PopularFlows({
                                         />
                                     </div>
                                 </div>
-                                <p className="font-bold text-gray-900 text-base leading-snug flex-1">
+                                <p className="font-medium text-gray-900 text-base leading-snug flex-1">
                                     {combo.description}
                                 </p>
-                                <span className="text-accent font-medium text-sm flex items-center gap-1">
+                                <span className="text-accent font-medium text-sm flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                                     Use this flow <ArrowRight className="w-3.5 h-3.5" aria-hidden="true" />
                                 </span>
                             </a>

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
@@ -1,109 +1,28 @@
 'use client';
 import Image from 'next/image';
-import { ArrowRightLeft, ChevronDown, ArrowRight, ArrowDownUp } from 'lucide-react';
-import TriggerOrActionCard from './TriggerOrActionCard';
-import { handleRedirect } from '@/utils/handleRedirection';
+import { ChevronDown, ArrowRight } from 'lucide-react';
 
 export default function PopularFlows({
     combosData,
     appOneDetails,
     appTwoDetails,
-    currentAppOne,
-    currentAppTwo,
-    appOneEvents,
-    appTwoEvents,
-    openDropdown,
-    setOpenDropdown,
-    selectedTrigger,
-    setSelectedTrigger,
-    selectedAction,
-    setSelectedAction,
-    resetTrigger,
     visibleCombos,
     setVisibleCombos,
     showMore,
     setShowMore,
-    handleSwapApps,
 }) {
-    const canBuildFlow = Boolean(selectedTrigger && selectedAction);
     const hasCombinations = combosData?.combinations?.length > 0;
 
     if (!hasCombinations) return null;
 
     return (
-        <div className="container flex flex-col gap-8">
+        <div className="container flex flex-col gap-8 mt-12">
             <div className="flex flex-col gap-3">
                 <h2 className="h2">
                     Popular {appOneDetails?.name} + {appTwoDetails?.name} flows
                 </h2>
-                <p className="text-gray-600 max-w-xl">
-                    Start from a real workflow other teams are already running.
-                </p>
+                <p className="text-gray-600 max-w-xl">Start from a real workflow other teams are already running.</p>
             </div>
-
-            {/* Builder */}
-            {/* <div className="flex flex-col items-start w-full">
-                <div className="flex flex-col md:flex-row justify-start items-center w-full max-w-6xl gap-6">
-                    <TriggerOrActionCard
-                        title="Choose a trigger"
-                        appDetails={currentAppOne}
-                        placeholder="Search triggers..."
-                        list={appOneEvents.triggers}
-                        isOpen={openDropdown === 'trigger'}
-                        onToggle={() => setOpenDropdown(openDropdown === 'trigger' ? null : 'trigger')}
-                        onSelect={(event) => setSelectedTrigger(event)}
-                        type="trigger"
-                        resetEvent={resetTrigger}
-                    />
-
-                    <div className="flex flex-col items-center justify-center">
-                        <button
-                            onClick={handleSwapApps}
-                            className="btn btn-outline p-4 flex items-center gap-2 md:hidden"
-                            aria-label="Swap apps"
-                        >
-                            <ArrowDownUp className="w-5 h-5" />
-                        </button>
-                        <button
-                            onClick={handleSwapApps}
-                            className="hidden md:flex items-center justify-center mt-8 text-gray-400 hover:text-accent transition-colors"
-                            aria-label="Swap apps"
-                        >
-                            <ArrowRightLeft className="w-5 h-5" />
-                        </button>
-                    </div>
-
-                    <TriggerOrActionCard
-                        title="Choose an action"
-                        appDetails={currentAppTwo}
-                        placeholder="Search actions..."
-                        list={appTwoEvents.actions}
-                        isOpen={openDropdown === 'action'}
-                        onToggle={() => setOpenDropdown(openDropdown === 'action' ? null : 'action')}
-                        onSelect={(event) => setSelectedAction(event)}
-                        type="action"
-                        resetEvent={resetTrigger}
-                    />
-
-                    <button
-                        onClick={(e) => {
-                            if (!canBuildFlow) return;
-                            handleRedirect(
-                                e,
-                                `${process.env.NEXT_PUBLIC_FLOW_URL}/makeflow/trigger/${selectedTrigger.rowid}/action?events=${selectedAction.rowid}&integrations=${selectedTrigger.pluginrecordid},${selectedAction.pluginrecordid}&action&`
-                            );
-                        }}
-                        disabled={!canBuildFlow}
-                        aria-disabled={!canBuildFlow}
-                        className={`btn btn-accent px-8 py-3 md:mt-8 max-md:w-full shrink-0 whitespace-nowrap transition-opacity ${
-                            canBuildFlow ? '' : 'opacity-40 cursor-not-allowed'
-                        }`}
-                    >
-                        Build this flow
-                    </button>
-                </div>
-            </div> */}
-
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {combosData?.combinations
                     ?.filter((combo) => combo?.description && !/^(List|Get)\b/i.test(combo.description.trim()))
@@ -140,10 +59,7 @@ export default function PopularFlows({
                                             className="w-6 h-6 object-contain"
                                         />
                                     </div>
-                                    <ArrowRight
-                                        className="w-3.5 h-3.5 text-gray-400 shrink-0"
-                                        aria-hidden="true"
-                                    />
+                                    <ArrowRight className="w-3.5 h-3.5 text-gray-400 shrink-0" aria-hidden="true" />
                                     <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
                                         <Image
                                             src={actionIconUrl}

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
@@ -246,9 +246,6 @@ export default function IntegrationsAppTwoClientComp({
             {/* 14. Final CTA */}
             <FinalCTA appOneDetails={appOneDetails} appTwoDetails={appTwoDetails} utm={utm} hasToken={hasToken} />
 
-            {/* 10. FAQs */}
-            {faqData && <FAQSection faqData={faqData} />}
-
             {/* About App A and About App B */}
             <AboutApps
                 appOneDetails={appOneDetails}
@@ -257,6 +254,9 @@ export default function IntegrationsAppTwoClientComp({
                 similarAppsTwo={similarAppsTwo}
                 getDoFollowUrlStatusArray={getDoFollowUrlStatusArray}
             />
+
+            {/* 10. FAQs */}
+            {faqData && <FAQSection faqData={faqData} />}
 
             <ConditionalFooter>
                 <Footer footerData={footerData} />

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
@@ -26,6 +26,8 @@ export default function IntegrationsAppTwoClientComp({
     footerData,
     appOneDetails,
     appTwoDetails,
+    similarAppsOne,
+    similarAppsTwo,
     blogsData,
     videoData,
     getDoFollowUrlStatusArray,
@@ -251,6 +253,8 @@ export default function IntegrationsAppTwoClientComp({
             <AboutApps
                 appOneDetails={appOneDetails}
                 appTwoDetails={appTwoDetails}
+                similarAppsOne={similarAppsOne}
+                similarAppsTwo={similarAppsTwo}
                 getDoFollowUrlStatusArray={getDoFollowUrlStatusArray}
             />
 

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoComp.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoComp.js
@@ -9,6 +9,8 @@ export default function IntegrationsAppTwoComp({
     footerData,
     appOneDetails,
     appTwoDetails,
+    similarAppsOne,
+    similarAppsTwo,
     blogsData,
     metaData,
     videoData,
@@ -38,6 +40,8 @@ export default function IntegrationsAppTwoComp({
                 blogsData={blogsData}
                 appOneDetails={appOneDetails}
                 appTwoDetails={appTwoDetails}
+                similarAppsOne={similarAppsOne}
+                similarAppsTwo={similarAppsTwo}
                 combosData={combosData}
                 footerData={footerData}
                 videoData={videoData}


### PR DESCRIPTION
## Summary
- Restructures the "About [App]" section on `/integrations/[app1]/[app2]` pair pages into two full-width rows, each with a breadcrumb, About content, and a new **Similar Apps** sidebar for SEO internal linking — the first batch of links are real server-rendered `<a href>` tags (crawlable), with a client-side "Load More" for additional apps.
- Similar apps are sourced server-side by matching each app's category (`integration-data.js`), threaded through `IntegrationsMain` → `IntegrationsAppTwoComp` → `IntegrationsAppTwoClientComp` → `AboutApps`, so this ships across every app-pair page, not just one.
- Hero section: app-icon-to-icon row above the title, updated feature badges (2000+ Integrations / AI Powered / Built to Scale), floating-bubble layout for the popular use cases list.
- Popular-flows builder: left-aligned trigger/action selectors with the "Build this flow" CTA inline at the same level (currently commented out pending final review).

## Test plan
- [ ] Visit a few `/integrations/[app1]/[app2]` pages and confirm the Similar Apps sidebar renders with real links and "Load More" works
- [ ] View source on a pair page and confirm the first batch of similar-app links are present in the raw HTML
- [ ] Check hero section renders correctly across viewport sizes
- [ ] Confirm no regressions on existing About/Learn more/category chip links