### PR TITLE
Restore trigger/action builder in Popular Flows section

### DIFF
--- a/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
@@ -1,17 +1,82 @@
 'use client';
 import Image from 'next/image';
-import { ChevronDown, ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ArrowRightLeft, ChevronDown, ArrowRight, ArrowDownUp } from 'lucide-react';
+import TriggerOrActionCard from './TriggerOrActionCard';
+
+function ComboCard({ triggerIconUrl, actionIconUrl, triggerAppName, actionAppName, description, link, alwaysShowCta }) {
+    return (
+        <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-white rounded-xl border custom-border p-6 flex flex-col gap-4 hover:shadow-md transition-shadow group"
+        >
+            <div className="flex items-center gap-2">
+                <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
+                    <Image
+                        src={triggerIconUrl}
+                        width={28}
+                        height={28}
+                        alt={`${triggerAppName} logo`}
+                        className="w-6 h-6 object-contain"
+                    />
+                </div>
+                <ArrowRight className="w-3.5 h-3.5 text-gray-400 shrink-0" aria-hidden="true" />
+                <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
+                    <Image
+                        src={actionIconUrl}
+                        width={28}
+                        height={28}
+                        alt={`${actionAppName} logo`}
+                        className="w-6 h-6 object-contain"
+                    />
+                </div>
+            </div>
+            <p className="font-medium text-gray-900 text-base leading-snug flex-1">{description}</p>
+            <span
+                className={`text-accent font-medium text-sm flex items-center gap-1 transition-opacity ${
+                    alwaysShowCta ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                }`}
+            >
+                Use this flow <ArrowRight className="w-3.5 h-3.5" aria-hidden="true" />
+            </span>
+        </a>
+    );
+}
 
 export default function PopularFlows({
     combosData,
     appOneDetails,
     appTwoDetails,
+    currentAppOne,
+    currentAppTwo,
+    appOneEvents,
+    appTwoEvents,
+    openDropdown,
+    setOpenDropdown,
+    selectedTrigger,
+    setSelectedTrigger,
+    selectedAction,
+    setSelectedAction,
+    resetTrigger,
     visibleCombos,
     setVisibleCombos,
     showMore,
     setShowMore,
+    handleSwapApps,
 }) {
+    const canBuildFlow = Boolean(selectedTrigger && selectedAction);
     const hasCombinations = combosData?.combinations?.length > 0;
+
+    const [showCtaAlways, setShowCtaAlways] = useState(false);
+
+    useEffect(() => {
+        if (!canBuildFlow) return;
+        setShowCtaAlways(true);
+        const timer = setTimeout(() => setShowCtaAlways(false), 5000);
+        return () => clearTimeout(timer);
+    }, [canBuildFlow, selectedTrigger, selectedAction]);
 
     if (!hasCombinations) return null;
 
@@ -23,7 +88,65 @@ export default function PopularFlows({
                 </h2>
                 <p className="text-gray-600 max-w-xl">Start from a real workflow other teams are already running.</p>
             </div>
+
+            {/* Builder */}
+            <div className="flex flex-col items-start w-full">
+                <div className="flex flex-col md:flex-row justify-start items-center w-full max-w-6xl gap-6">
+                    <TriggerOrActionCard
+                        title="Choose a trigger"
+                        appDetails={currentAppOne}
+                        placeholder="Search triggers..."
+                        list={appOneEvents.triggers}
+                        isOpen={openDropdown === 'trigger'}
+                        onToggle={() => setOpenDropdown(openDropdown === 'trigger' ? null : 'trigger')}
+                        onSelect={(event) => setSelectedTrigger(event)}
+                        type="trigger"
+                        resetEvent={resetTrigger}
+                    />
+
+                    <div className="flex flex-col items-center justify-center">
+                        <button
+                            onClick={handleSwapApps}
+                            className="btn btn-outline p-4 flex items-center gap-2 md:hidden"
+                            aria-label="Swap apps"
+                        >
+                            <ArrowDownUp className="w-5 h-5" />
+                        </button>
+                        <button
+                            onClick={handleSwapApps}
+                            className="hidden md:flex items-center justify-center mt-8 text-gray-400 hover:text-accent transition-colors"
+                            aria-label="Swap apps"
+                        >
+                            <ArrowRightLeft className="w-5 h-5" />
+                        </button>
+                    </div>
+
+                    <TriggerOrActionCard
+                        title="Choose an action"
+                        appDetails={currentAppTwo}
+                        placeholder="Search actions..."
+                        list={appTwoEvents.actions}
+                        isOpen={openDropdown === 'action'}
+                        onToggle={() => setOpenDropdown(openDropdown === 'action' ? null : 'action')}
+                        onSelect={(event) => setSelectedAction(event)}
+                        type="action"
+                        resetEvent={resetTrigger}
+                    />
+                </div>
+            </div>
+
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {canBuildFlow && (
+                    <ComboCard
+                        triggerIconUrl={currentAppOne?.iconurl || 'https://placehold.co/36x36'}
+                        actionIconUrl={currentAppTwo?.iconurl || 'https://placehold.co/36x36'}
+                        triggerAppName={currentAppOne?.name || 'App'}
+                        actionAppName={currentAppTwo?.name || 'App'}
+                        description={`${selectedAction?.name} in ${currentAppTwo?.name} when ${selectedTrigger?.name} in ${currentAppOne?.name}`}
+                        link={`${process.env.NEXT_PUBLIC_FLOW_URL}/makeflow/trigger/${selectedTrigger?.rowid}/action?events=${selectedAction?.rowid}&integrations=${selectedTrigger?.pluginrecordid},${selectedAction?.pluginrecordid}&action&`}
+                        alwaysShowCta={showCtaAlways}
+                    />
+                )}
                 {combosData?.combinations
                     ?.filter((combo) => combo?.description && !/^(List|Get)\b/i.test(combo.description.trim()))
                     ?.slice(0, visibleCombos)
@@ -42,41 +165,15 @@ export default function PopularFlows({
                             ?.map((action) => action?.id)
                             .join(',')}&integrations=${integrations}&action&`;
                         return (
-                            <a
+                            <ComboCard
                                 key={index}
-                                href={link}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="bg-white rounded-xl border custom-border p-6 flex flex-col gap-4 hover:shadow-md transition-shadow group"
-                            >
-                                <div className="flex items-center gap-2">
-                                    <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
-                                        <Image
-                                            src={triggerIconUrl}
-                                            width={28}
-                                            height={28}
-                                            alt={`${triggerAppName} logo`}
-                                            className="w-6 h-6 object-contain"
-                                        />
-                                    </div>
-                                    <ArrowRight className="w-3.5 h-3.5 text-gray-400 shrink-0" aria-hidden="true" />
-                                    <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">
-                                        <Image
-                                            src={actionIconUrl}
-                                            width={28}
-                                            height={28}
-                                            alt={`${actionAppName} logo`}
-                                            className="w-6 h-6 object-contain"
-                                        />
-                                    </div>
-                                </div>
-                                <p className="font-medium text-gray-900 text-base leading-snug flex-1">
-                                    {combo.description}
-                                </p>
-                                <span className="text-accent font-medium text-sm flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                    Use this flow <ArrowRight className="w-3.5 h-3.5" aria-hidden="true" />
-                                </span>
-                            </a>
+                                triggerIconUrl={triggerIconUrl}
+                                actionIconUrl={actionIconUrl}
+                                triggerAppName={triggerAppName}
+                                actionAppName={actionAppName}
+                                description={combo.description}
+                                link={link}
+                            />
                         );
                     })}
             </div>


### PR DESCRIPTION
## Summary
- Restores the trigger/action picker in the "Popular X + Y flows" section (previously removed in a "simplify" pass) — users can choose a trigger from app one and an action from app two directly, without needing a pre-built combo.
- Removes the separate "Build this flow" CTA button. Instead, the selected trigger + action combination now renders as the first card in the flows grid, using the same card component as the pre-built combos, with a working link to the flow builder.
- The "Use this flow" link on that card shows immediately for 5 seconds after selection, then falls back to the same hover-reveal behavior as the other cards.

## Test plan
- [ ] Visit an app-pair integration page with real combo data (e.g. `/integrations/google-sheets/shopify`)
- [ ] Pick a trigger and an action in the builder and confirm a new card appears first in the grid with the correct description and a working flow-builder link
- [ ] Confirm the "Use this flow" text is visible immediately, then fades to hover-only after ~5s
- [ ] Confirm existing pre-built combo cards are unaffected (still hover-reveal, link correctly)