### PR TITLE
Add getCookieDomain helper and set cookies with root domain attribute…

### DIFF
--- a/src/utils/handleUtmSource.js
+++ b/src/utils/handleUtmSource.js
@@ -4,11 +4,22 @@ export const getCookie = (name) => {
     if (parts.length === 2) return parts.pop().split(';').shift();
 };
 
+const getCookieDomain = () => {
+    if (typeof window === 'undefined') return '';
+    const hostname = window.location.hostname;
+    if (!hostname || hostname === 'localhost' || hostname === '127.0.0.1') return '';
+    const parts = hostname.split('.');
+    const rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
+    return `.${rootDomain}`;
+};
+
 export const setCookie = (name, value, days) => {
     const date = new Date();
     date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
     const expires = `expires=${date.toUTCString()}`;
-    document.cookie = `${name}=${value};${expires};path=/`;
+    const domain = getCookieDomain();
+    const domainAttr = domain ? `;domain=${domain}` : '';
+    document.cookie = `${name}=${value};${expires};path=/${domainAttr}`;
 };
 
 export const getUtmSource = () => {

--- a/src/utils/handleUtmSource.js
+++ b/src/utils/handleUtmSource.js
@@ -7,7 +7,7 @@ export const getCookie = (name) => {
 const getCookieDomain = () => {
     if (typeof window === 'undefined') return '';
     const hostname = window.location.hostname;
-    if (!hostname || hostname === 'localhost' || hostname === '127.0.0.1') return '';
+    if (!hostname) return '';
     const parts = hostname.split('.');
     const rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
     return `.${rootDomain}`;


### PR DESCRIPTION
… for cross-subdomain sharing

Add getCookieDomain function to determine root domain from hostname (handling localhost/127.0.0.1 cases), and update setCookie to include domain attribute when setting cookies to enable sharing across subdomains (e.g., .viasocket.com). || 1