### PR TITLE
Update MigratingBanner for Relay.app shutdown, add fallback for use c…

### DIFF
--- a/src/app/components/navbar/MigratingBanner.js
+++ b/src/app/components/navbar/MigratingBanner.js
@@ -7,14 +7,19 @@ export default function MigratingBanner() {
             className={`hidden lg:flex cursor-pointer w-full bg-[#3B62FF] text-white backdrop-blur-xl [-webkit-backdrop-filter:blur(24px)] !h-[30px] items-center justify-center gap-2 !text-sm`}
         >
             <span className="tracking-[0.06em]">
-                Migrating from another tool? We'll move your workflows for you, <strong>Free</strong>.
+                Relay.app is shutting down. We'll move your workflows to viaSocket for you, <strong>Free</strong>.
             </span>
+            <Link href={'/signup?import=true'} target="_blank" rel="nofollow noopener noreferrer">
+                <div className="border border-white bg-white text-black rounded-full px-3 py-1 flex items-center gap-1 cursor-pointer hover:bg-gray-100 transition-colors !h-[20px] !text-xs">
+                    Import Flow <ArrowRight className="w-3 h-3" />
+                </div>
+            </Link>
             <Link
                 href={'https://cal.id/team/viasocket/workflow-setup-discussion'}
                 target="_blank"
                 rel="nofollow noopener noreferrer"
             >
-                <div className="border border-white bg-white text-black rounded-full px-3 py-1 flex items-center gap-1 cursor-pointer hover:bg-gray-100 transition-colors mx-2 !h-[20px] !text-xs">
+                <div className="border border-white bg-white text-black rounded-full px-3 py-1 flex items-center gap-1 cursor-pointer hover:bg-gray-100 transition-colors !h-[20px] !text-xs">
                     Talk to us <ArrowRight className="w-3 h-3" />
                 </div>
             </Link>

--- a/src/app/lib/integration-data.js
+++ b/src/app/lib/integration-data.js
@@ -47,8 +47,8 @@ function transformAppData(app) {
         appDescription: app.app_description,
 
         headings: {
-            h1: app.h1_title,
-            subheadline: app.subheadline,
+            h1: app.herosection_new || app.h1_title,
+            subheadline: app.subheadlinie_new || app.subheadline,
         },
 
         metadata: {

--- a/src/components/IntegrationsComp/integrationsAppOneComp/realWorldUseCase.js
+++ b/src/components/IntegrationsComp/integrationsAppOneComp/realWorldUseCase.js
@@ -107,8 +107,14 @@ const RealWorldUseCase = ({ appOneDetails, combosData, appCount, appData }) => {
 
     const dynamicUseCases = useMemo(() => {
         const raw = appData?.useCasesNewData || [];
-        return Array.isArray(raw) ? raw.map(getUseCaseText).filter(Boolean) : [];
-    }, [appData?.useCasesNewData]);
+        if (Array.isArray(raw) && raw.length > 0) {
+            return raw.map(getUseCaseText).filter(Boolean);
+        }
+        const fallback = appData?.useCasesCardsData || [];
+        return Array.isArray(fallback)
+            ? fallback.map((item) => (typeof item === 'string' ? item : item?.title || '')).filter(Boolean)
+            : [];
+    }, [appData?.useCasesNewData, appData?.useCasesCardsData]);
 
     // Get dynamic app icons from combosData
     const dynamicApps = useMemo(() => {

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/AIFeatureSection.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/AIFeatureSection.js
@@ -7,7 +7,7 @@ export default function AIFeatureSection({ appOneName, appTwoName }) {
 
     return (
         <div className="container">
-            <div className="flex flex-col md:flex-row items-stretch justify-around gap-10 md:gap-16">
+            <div className="flex flex-col md:flex-row items-stretch justify-between gap-10 md:gap-20">
                 {/* Left: product screenshot (dark app UI image) */}
                 <div className="w-full md:w-[38%] shrink-0 rounded-xl overflow-hidden">
                     <Image

--- a/src/const/fields.js
+++ b/src/const/fields.js
@@ -40,7 +40,16 @@ export const MCP_FIELDS = ['action', 'description', 'name', 'prompt', 'slug_name
 export const PRICINGFEATURE_FIELDS = ['featurename'];
 export const INDEXTEMPLATE_FIELDS = ['name', 'scriptId', 'bgcolor'];
 export const DOFOLLOWLINK_FIELDS = ['appslugname'];
-export const REVIEWSECTION_FIELDS = ['name', 'user_name', 'subtitle', 'description', 'date', 'link', 'user_profile', 'platform_logo'];
+export const REVIEWSECTION_FIELDS = [
+    'name',
+    'user_name',
+    'subtitle',
+    'description',
+    'date',
+    'link',
+    'user_profile',
+    'platform_logo',
+];
 export const FEATUREBANNER_FIELDS = ['bgimage'];
 export const NAVBAR_FIELDS = ['group_name', 'name', 'link', 'is_link', 'group_link'];
 export const BLACKFRIDAYSALE_FIELDS = [
@@ -62,5 +71,20 @@ export const DEPARTMENTDATA_FIELDS = [
     'card_image',
 ];
 export const TEMPLATEMARQUEEITEMS_FIELDS = ['name', 'slug', 'icon', 'is_app'];
-export const SINGLEAPP_FIELDS = ['app_name', 'app_description', 'app_slug', 'primary_keyword', 'secondary_keywords', 'page_title', 'meta_description', 'h1_title', 'subheadline', 'use_case_cards', 'faqs', 'usecases_new'];
+export const SINGLEAPP_FIELDS = [
+    'app_name',
+    'app_description',
+    'app_slug',
+    'primary_keyword',
+    'secondary_keywords',
+    'page_title',
+    'meta_description',
+    'h1_title',
+    'subheadline',
+    'herosection_new',
+    'subheadlinie_new',
+    'use_case_cards',
+    'faqs',
+    'usecases_new',
+];
 export const FEATUREDTEMPLATES_FIELDS = ['name'];


### PR DESCRIPTION
…ases, and support new hero section fields

- Change MigratingBanner text to mention Relay.app shutdown specifically
- Add "Move to viaSocket" CTA button linking to signup with import parameter
- Remove mx-2 margin from "Talk to us" button for consistent spacing
- Add herosection_new and subheadlinie_new fields to SINGLEAPP_FIELDS
- Update integration-data.js to use new hero section fields with fallback to original h1_title/subheadline
- Add || 1