### PR TITLE
Remove import query parameter from login redirect destination

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -50,7 +50,7 @@ const nextConfig = {
             {
                 source: '/login',
                 has: [{ type: 'query', key: 'import', value: 'true' }],
-                destination: 'https://flow.viasocket.com/org?import=true',
+                destination: 'https://flow.viasocket.com/org',
                 permanent: false,
             },
             {


### PR DESCRIPTION
- Change login redirect destination from /org?import=true to /org when import=true parameter is present
- Keep import parameter detection in source but simplify destination URL || TEST