### PR TITLE
Search component improvements

### DIFF
--- a/src/app/components/home/SearchInputHomeOptimized.js
+++ b/src/app/components/home/SearchInputHomeOptimized.js
@@ -27,6 +27,7 @@ const getFirstSuggestion = (apps, industries, departments, search) => {
         if (!list || list.length === 0) return null;
         const item = list[0];
         const name = item?.name || item?.industry_name || item?.department_name || item;
+        if (typeof name !== 'string') return null;
         return name.toLowerCase().startsWith(lower) ? { suggestion: name, type } : null;
     };
 
@@ -460,27 +461,30 @@ export default function SearchInputHomeOptimized({
                             const custom = searchTerm.trim();
                             setCustomIndustry(custom);
                             if (!selectedIndustries.includes(custom)) {
-                                setSelectedIndustries((prev) => [...prev, custom]);
+                                const newSelectedIndustries = [...selectedIndustries, custom];
+                                setSelectedIndustries(newSelectedIndustries);
                                 setSearchTerm('');
                                 setTimeout(() => {
                                     if (
                                         selectedApps.length > 0 ||
-                                        selectedIndustries.length > 0 ||
+                                        newSelectedIndustries.length > 0 ||
                                         selectedDepartments.length > 0 ||
                                         custom !== ''
                                     ) {
-                                        handleSearchTemplates();
-                                        if (enableVideos) handleSearchVideos();
-                                        if (enableBlogs) handleSearchBlogs();
+                                        handleSearchTemplates(selectedApps, newSelectedIndustries, selectedDepartments);
+                                        if (enableVideos)
+                                            handleSearchVideos(selectedApps, newSelectedIndustries, selectedDepartments);
+                                        if (enableBlogs)
+                                            handleSearchBlogs(selectedApps, newSelectedIndustries, selectedDepartments);
                                     }
                                     // Check AI response condition separately
                                     if (enableAi) {
                                         const shouldShowAiResponse =
                                             (selectedApps.length >= 1 &&
-                                                (selectedIndustries.length >= 1 || selectedDepartments.length >= 1)) ||
+                                                (newSelectedIndustries.length >= 1 || selectedDepartments.length >= 1)) ||
                                             selectedApps.length >= 1;
                                         if (shouldShowAiResponse) {
-                                            getAiResponse();
+                                            getAiResponse(selectedApps, newSelectedIndustries, selectedDepartments);
                                         } else {
                                             setShowAiResponse(false);
                                         }
@@ -830,7 +834,7 @@ export default function SearchInputHomeOptimized({
                                             <div
                                                 key={index}
                                                 className="flex items-center gap-2 cursor-pointer hover:bg-gray-100 p-4"
-                                                onClick={(e) => {
+                                                onMouseDown={(e) => {
                                                     e.preventDefault();
                                                     handleSelectIndustry(industry);
                                                 }}

--- a/src/app/components/home/SearchInputHomeOptimized.js
+++ b/src/app/components/home/SearchInputHomeOptimized.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import Image from 'next/image';
-import { Search } from 'lucide-react';
+import { Search, Loader2 } from 'lucide-react';
 import searchApps from '@/utils/searchApps';
 import { getIndustries, getDepartments } from '@/utils/axiosCalls';
 import { getVideoData } from '@/utils/getVideoData';
@@ -16,7 +16,7 @@ const filterListByName = (list, search) => {
 
     return list.filter((item) => {
         const name = (item?.name || '').trim().toLowerCase();
-        return name.startsWith(lower);
+        return name.includes(lower);
     });
 };
 
@@ -54,6 +54,9 @@ export default function SearchInputHomeOptimized({
     const dropdownRef = useRef(null);
     const inputRef = useRef(null);
     const allAppsCache = useRef(null);
+    const searchDebounceRef = useRef(null);
+    const searchAbortRef = useRef(null);
+    const [appSearchLoading, setAppSearchLoading] = useState(false);
     const [selectedApps, setSelectedApps] = useState([]);
     const [selectedIndustries, setSelectedIndustries] = useState([]);
     const [selectedDepartments, setSelectedDepartments] = useState([]);
@@ -341,26 +344,14 @@ export default function SearchInputHomeOptimized({
         });
     };
 
-    const handleSearch = useCallback(
-        async (value) => {
-            setSearchTerm(value);
-            setShowDropdown(true);
-            setCurrentSuggestion('');
-            setSuggestionText('');
-
-            if (!value.trim()) {
-                if (!allAppsCache.current) {
-                    const apps = initialApps;
-                    allAppsCache.current = apps;
-                }
-                setSearchData(filterSelectedApps(allAppsCache.current));
-                setFilteredIndustries(allIndustries);
-                setFilteredDepartments(allDepartments);
-                return;
-            }
-
+    const performAppSearch = useCallback(
+        async (value, controller) => {
             try {
-                const result = await searchApps(value);
+                setAppSearchLoading(true);
+                const result = await searchApps(value, controller.signal);
+                if (controller.signal.aborted) return;
+                setAppSearchLoading(false);
+
                 const filteredApps = filterSelectedApps(result);
                 // Sort the app results to prioritize exact matches
                 const sortedApps = sortSearchResults(filteredApps, value);
@@ -378,11 +369,51 @@ export default function SearchInputHomeOptimized({
                     setSuggestionText(firstSuggestion.suggestion.slice(value.length));
                 }
             } catch (error) {
-                console.error(error);
+                if (error?.name !== 'AbortError') console.error(error);
+                setAppSearchLoading(false);
             }
         },
         [allIndustries, allDepartments, filterSelectedApps]
     );
+
+    const handleSearch = useCallback(
+        (value) => {
+            setSearchTerm(value);
+            setShowDropdown(true);
+            setCurrentSuggestion('');
+            setSuggestionText('');
+
+            searchDebounceRef.current && clearTimeout(searchDebounceRef.current);
+
+            if (!value.trim()) {
+                searchAbortRef.current?.abort();
+                setAppSearchLoading(false);
+                if (!allAppsCache.current) {
+                    const apps = initialApps;
+                    allAppsCache.current = apps;
+                }
+                setSearchData(filterSelectedApps(allAppsCache.current));
+                setFilteredIndustries(allIndustries);
+                setFilteredDepartments(allDepartments);
+                return;
+            }
+
+            searchDebounceRef.current = setTimeout(() => {
+                searchAbortRef.current?.abort();
+                const controller = new AbortController();
+                searchAbortRef.current = controller;
+                performAppSearch(value, controller);
+            }, 400);
+        },
+        [allIndustries, allDepartments, filterSelectedApps, initialApps, performAppSearch]
+    );
+
+    useEffect(() => {
+        return () => {
+            searchDebounceRef.current && clearTimeout(searchDebounceRef.current);
+            searchAbortRef.current?.abort();
+        };
+    }, []);
 
     const handleKeyPress = (e) => {
         if (e.key === 'Tab' && currentSuggestion) {
@@ -599,7 +630,11 @@ export default function SearchInputHomeOptimized({
                         }
                     }}
                 >
-                    <Search className="w-5 h-5" />
+                    {appSearchLoading ? (
+                        <Loader2 className="w-5 h-5 animate-spin text-gray-400 shrink-0" aria-hidden="true" />
+                    ) : (
+                        <Search className="w-5 h-5" />
+                    )}
 
                     {selectedApps?.map((app) => (
                         <div

--- a/src/app/components/integrations-script/SetupBuilder.js
+++ b/src/app/components/integrations-script/SetupBuilder.js
@@ -23,6 +23,7 @@ export default function SetupBuilder({ initialApps = [] }) {
     const [refCode, setRefCode] = useState('');
     const [domain, setDomain] = useState('');
     const debounceRef = useRef(null);
+    const searchAbortRef = useRef(null);
     const preselectDoneRef = useRef(false);
     const [canSyncParams, setCanSyncParams] = useState(!preselectSlugs.length);
     const selectedAppSlugs = useMemo(() => slots.filter(Boolean).map((a) => a.appslugname), [slots]);
@@ -96,22 +97,30 @@ export default function SetupBuilder({ initialApps = [] }) {
     useEffect(() => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
         if (!query) {
+            searchAbortRef.current?.abort();
             setApps(initialApps);
             setLoading(false);
             return;
         }
         debounceRef.current = setTimeout(async () => {
+            searchAbortRef.current?.abort();
+            const controller = new AbortController();
+            searchAbortRef.current = controller;
             setLoading(true);
             try {
-                const res = await searchApps(query);
+                const res = await searchApps(query, controller.signal);
+                if (controller.signal.aborted) return;
                 setApps(Array.isArray(res) ? res.slice(0, 36) : []);
-            } catch {
-                setApps([]);
+            } catch (error) {
+                if (error?.name !== 'AbortError') setApps([]);
             } finally {
-                setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             }
         }, 250);
-        return () => debounceRef.current && clearTimeout(debounceRef.current);
+        return () => {
+            debounceRef.current && clearTimeout(debounceRef.current);
+            searchAbortRef.current?.abort();
+        };
     }, [query, initialApps]);
 
     const handleSelect = (app) => {

--- a/src/app/components/workflow-automation-ideas/AutomationSuggestionsClient.js
+++ b/src/app/components/workflow-automation-ideas/AutomationSuggestionsClient.js
@@ -5,6 +5,18 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import Image from 'next/image';
 import searchApps from '@/utils/searchApps';
 
+const EXCLUDED_APPS = [
+    'zapier',
+    'make.com',
+    'pabbly connect',
+    'workato',
+    'relay.app',
+    'integrately',
+    'microsoft power automate',
+    'ifttt',
+    'n8n',
+];
+
 const useDebounce = (value, delay) => {
     const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -21,6 +33,7 @@ const DropdownItem = ({ app, isChecked, handleSelect }) => (
         className={`flex items-center gap-2 px-3 py-2 cursor-pointer w-[300px] hover:bg-gray-100 ${
             isChecked ? 'bg-gray-200' : 'bg-white'
         }`}
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => handleSelect(app)}
     >
         <input
@@ -66,6 +79,7 @@ export default function AutomationSuggestionsClient() {
     const [searchData, setSearchData] = useState([]);
     const [combinationLoading, setCombinationLoading] = useState(true);
     const debounceValue = useDebounce(searchTerm, 300);
+    const searchAbortRef = useRef(null);
 
     const [renderCombos, setRenderCombos] = useState([]);
     const [selectedIndustry, setSelectedIndustry] = useState('');
@@ -78,8 +92,11 @@ export default function AutomationSuggestionsClient() {
 
     const filterSelectedApps = useCallback(
         (apps) =>
-            apps?.filter((app) => !selectedApps.some((selectedApp) => selectedApp.appslugname === app.appslugname)) ||
-            [],
+            apps?.filter(
+                (app) =>
+                    !selectedApps.some((selectedApp) => selectedApp.appslugname === app.appslugname) &&
+                    !EXCLUDED_APPS.includes((app?.name || '').toLowerCase())
+            ) || [],
         [selectedApps]
     );
 
@@ -122,26 +139,30 @@ export default function AutomationSuggestionsClient() {
     };
     
     useEffect(() => {
-        if (debounceValue !== '') {
-            filterApps();
-        }
+        searchAbortRef.current?.abort();
+        const controller = new AbortController();
+        searchAbortRef.current = controller;
+        filterApps(controller.signal);
+        return () => controller.abort();
     }, [debounceValue]);
 
     useEffect(() => {
         handleGenerate();
     }, []);
 
-    const filterApps = async () => {
+    const filterApps = async (signal) => {
         try {
             if (debounceValue) {
-                const result = await searchApps(debounceValue);
+                const result = await searchApps(debounceValue, signal);
+                if (signal?.aborted) return;
                 setSearchData(filterSelectedApps(result));
             } else {
                 const apps = await fetchAppsData();
+                if (signal?.aborted) return;
                 setSearchData(filterSelectedApps(apps));
             }
         } catch (error) {
-            console.error(error);
+            if (error?.name !== 'AbortError') console.error(error);
         }
     };
 
@@ -172,17 +193,6 @@ export default function AutomationSuggestionsClient() {
         };
     }, [dropdownRef]);
 
-    const excludedApps = [
-        'zapier',
-        'make.com',
-        'pabbly connect',
-        'workato',
-        'relay.app',
-        'Integrately',
-        'Microsoft Power Automate',
-        'IFTTT',
-        'n8n',
-    ];
 
     return (
         <>

--- a/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
+++ b/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
@@ -31,10 +31,6 @@ export default function IntegrationsIndexClientComp({
     appCount,
     categoryName,
 }) {
-    if (!categoryData || Object.keys(categoryData).length === 0) {
-        return <ErrorComp />;
-    }
-
     const [searchTerm, setSearchTerm] = useState('');
     const [debounceValue, setDebounceValue] = useState('');
     const [searchedApps, setSearchedApps] = useState([]);
@@ -45,7 +41,7 @@ export default function IntegrationsIndexClientComp({
 
     const filterPriorityCategories = (cats) => {
         if (!Array.isArray(cats)) return [];
-        return cats.sort((a, b) => {
+        return [...cats].sort((a, b) => {
             const priorityA = Number(a.priority) || Infinity;
             const priorityB = Number(b.priority) || Infinity;
             return priorityA - priorityB || a.name.localeCompare(b.name);
@@ -133,6 +129,10 @@ export default function IntegrationsIndexClientComp({
             return url;
         }
     };
+
+    if (!categoryData || Object.keys(categoryData).length === 0) {
+        return <ErrorComp />;
+    }
 
     return (
         <>

--- a/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
+++ b/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { Search, ArrowUpRight, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Search, ArrowUpRight, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import Footer from '@/components/footer/footer';
 import ConditionalFooter from '@/components/ConditionalLayout/ConditionalFooter';
 import style from './IntegrationsIndexComp.module.scss';
@@ -39,7 +39,9 @@ export default function IntegrationsIndexClientComp({
     const [debounceValue, setDebounceValue] = useState('');
     const [searchedApps, setSearchedApps] = useState([]);
     const [searchedCategoies, setSearchedCategoies] = useState();
+    const [searchLoading, setSearchLoading] = useState(false);
     const searchInputRef = useRef(null);
+    const abortControllerRef = useRef(null);
 
     const filterPriorityCategories = (cats) => {
         if (!Array.isArray(cats)) return [];
@@ -69,12 +71,20 @@ export default function IntegrationsIndexClientComp({
                 category?.name?.toLowerCase()?.includes(debounceValue.toLowerCase())
             );
             setSearchedCategoies(filterPriorityCategories(filteredCategories));
+
+            abortControllerRef.current?.abort();
+            const controller = new AbortController();
+            abortControllerRef.current = controller;
+
             const loadApps = async () => {
-                const fetchedApps = await searchApps(debounceValue);
+                setSearchLoading(true);
+                const fetchedApps = await searchApps(debounceValue, controller.signal);
+                if (controller.signal.aborted) return;
+                setSearchLoading(false);
                 if (!fetchedApps) {
                     setSearchedApps([]);
                 } else {
-                    const searchTermLower = searchTerm.toLowerCase();
+                    const searchTermLower = debounceValue.toLowerCase();
                     const sortedApps = fetchedApps.sort((a, b) => {
                         const aName = a?.name?.toLowerCase() || '';
                         const bName = b?.name?.toLowerCase() || '';
@@ -97,9 +107,14 @@ export default function IntegrationsIndexClientComp({
             };
             loadApps();
         } else {
+            abortControllerRef.current?.abort();
+            setSearchLoading(false);
             setSearchedApps([]);
             setSearchedCategoies();
         }
+        return () => {
+            abortControllerRef.current?.abort();
+        };
     }, [debounceValue]);
 
     const showNext = apps?.length > 0 && APPERPAGE <= apps?.length;
@@ -180,6 +195,7 @@ export default function IntegrationsIndexClientComp({
                             placeholder="Search your favorite tools "
                             autoFocus
                         />
+                        {searchLoading && <Loader2 className="w-4 h-4 animate-spin text-gray-400 shrink-0" aria-hidden="true" />}
                     </label>
                 </div>
 

--- a/src/components/IntegrationsComp/integrationsAppComp/integrationSearchApps.js
+++ b/src/components/IntegrationsComp/integrationsAppComp/integrationSearchApps.js
@@ -12,6 +12,7 @@ const IntegrationSearchApps = ({
     onSearchResults,
     onCategoriesResults,
     onDebounceValueChange,
+    onLoadingChange,
     app,
 }) => {
     const [debounceValue, setDebounceValue] = useState('');
@@ -34,6 +35,7 @@ const IntegrationSearchApps = ({
         if (!debounceValue) {
             abortControllerRef.current?.abort();
             setSearchLoading(false);
+            onLoadingChange && onLoadingChange(false);
             onSearchResults && onSearchResults([]);
             onCategoriesResults && onCategoriesResults(null);
             onDebounceValueChange && onDebounceValueChange('');
@@ -57,9 +59,11 @@ const IntegrationSearchApps = ({
 
             // Search apps
             setSearchLoading(true);
+            onLoadingChange && onLoadingChange(true);
             const fetchedApps = await searchApps(debounceValue, controller.signal);
             if (controller.signal.aborted) return;
             setSearchLoading(false);
+            onLoadingChange && onLoadingChange(false);
             if (!fetchedApps) {
                 onSearchResults && onSearchResults([]);
                 return;
@@ -90,7 +94,7 @@ const IntegrationSearchApps = ({
         return () => {
             abortControllerRef.current?.abort();
         };
-    }, [debounceValue, onSearchResults, onCategoriesResults, onDebounceValueChange]);
+    }, [debounceValue, onSearchResults, onCategoriesResults, onDebounceValueChange, onLoadingChange]);
 
     return (
         <>

--- a/src/components/IntegrationsComp/integrationsAppComp/integrationSearchApps.js
+++ b/src/components/IntegrationsComp/integrationsAppComp/integrationSearchApps.js
@@ -1,7 +1,7 @@
 'use client';
 
-import { Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Search, Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import categories from '@/data/categories.json';
 import searchApps from '@/utils/searchApps';
 import style from './IntegrationsAppComp.module.scss';
@@ -15,6 +15,8 @@ const IntegrationSearchApps = ({
     app,
 }) => {
     const [debounceValue, setDebounceValue] = useState('');
+    const [searchLoading, setSearchLoading] = useState(false);
+    const abortControllerRef = useRef(null);
 
     // Debounce effect
     useEffect(() => {
@@ -29,14 +31,20 @@ const IntegrationSearchApps = ({
 
     // Search effect
     useEffect(() => {
-        const search = async () => {
-            if (!debounceValue) {
-                onSearchResults && onSearchResults([]);
-                onCategoriesResults && onCategoriesResults(null);
-                onDebounceValueChange && onDebounceValueChange('');
-                return;
-            }
+        if (!debounceValue) {
+            abortControllerRef.current?.abort();
+            setSearchLoading(false);
+            onSearchResults && onSearchResults([]);
+            onCategoriesResults && onCategoriesResults(null);
+            onDebounceValueChange && onDebounceValueChange('');
+            return;
+        }
 
+        abortControllerRef.current?.abort();
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        const search = async () => {
             onDebounceValueChange && onDebounceValueChange(debounceValue);
 
             const searchTermLower = debounceValue.toLowerCase();
@@ -48,7 +56,10 @@ const IntegrationSearchApps = ({
             onCategoriesResults && onCategoriesResults(filteredCategories);
 
             // Search apps
-            const fetchedApps = await searchApps(debounceValue);
+            setSearchLoading(true);
+            const fetchedApps = await searchApps(debounceValue, controller.signal);
+            if (controller.signal.aborted) return;
+            setSearchLoading(false);
             if (!fetchedApps) {
                 onSearchResults && onSearchResults([]);
                 return;
@@ -76,6 +87,9 @@ const IntegrationSearchApps = ({
         };
 
         search();
+        return () => {
+            abortControllerRef.current?.abort();
+        };
     }, [debounceValue, onSearchResults, onCategoriesResults, onDebounceValueChange]);
 
     return (
@@ -92,6 +106,7 @@ const IntegrationSearchApps = ({
                     className={`${style.input} grow truncate w-48`}
                     placeholder={`Search any app to connect with ${app?.name || 'apps'}`}
                 />
+                {searchLoading && <Loader2 className="w-4 h-4 animate-spin text-gray-400 shrink-0" aria-hidden="true" />}
             </label>
         </>
     );

--- a/src/components/IntegrationsComp/integrationsAppComp/integrationsAppComp.js
+++ b/src/components/IntegrationsComp/integrationsAppComp/integrationsAppComp.js
@@ -13,6 +13,7 @@ export default function IntegrationsAppComp({
     appCount,
     searchTerm,
     searchedCategories,
+    searchLoading = false,
 }) {
 
     return (
@@ -107,14 +108,14 @@ export default function IntegrationsAppComp({
                                             </div>
                                         </Link>
                                     ))
-                                ) : (
+                                ) : !searchLoading ? (
                                     <div className="col-span-full row-span-1 md:row-span-2 min-h-[200px] md:min-h-[150px]">
                                         <RequestIntegrationPopupOpener
                                             showType="searchView"
                                             className="md:border-t-0 md:border-l-0"
                                         />
                                     </div>
-                                )
+                                ) : null
                             ) : (
                                 apps
                                     ?.filter((app) => !app?.category?.some((cat) => appCategories?.includes(cat)))

--- a/src/components/IntegrationsComp/integrationsAppOneComp/connectAppsSection.js
+++ b/src/components/IntegrationsComp/integrationsAppOneComp/connectAppsSection.js
@@ -30,6 +30,7 @@ export default function ConnectAppsSection({ brandColor, appOneDetails, apps, pa
   const [searchTerm, setSearchTerm] = useState("");
   const [searchedApps, setSearchedApps] = useState([]);
   const [debounceValue, setDebounceValue] = useState("");
+  const [searchLoading, setSearchLoading] = useState(false);
 
   const appName = appOneDetails?.name || "App";
   const appSlug = appOneDetails?.appslugname;
@@ -41,6 +42,10 @@ export default function ConnectAppsSection({ brandColor, appOneDetails, apps, pa
 
   const handleDebounceValueChange = useCallback((value) => {
     setDebounceValue(value);
+  }, []);
+
+  const handleLoadingChange = useCallback((loading) => {
+    setSearchLoading(loading);
   }, []);
 
   const showNext = apps?.length > 0 && APPERPAGE <= apps?.length;
@@ -95,6 +100,7 @@ export default function ConnectAppsSection({ brandColor, appOneDetails, apps, pa
             setSearchTerm={setSearchTerm}
             onSearchResults={handleSearchResults}
             onDebounceValueChange={handleDebounceValueChange}
+            onLoadingChange={handleLoadingChange}
             app={appOneDetails}
           />
         </div>
@@ -112,7 +118,7 @@ export default function ConnectAppsSection({ brandColor, appOneDetails, apps, pa
             ))}
           </div>
 
-          {debounceValue && (!displayApps || displayApps.length === 0) && (
+          {debounceValue && !searchLoading && (!displayApps || displayApps.length === 0) && (
             <div className="flex flex-col items-center justify-center py-12">
               <span>No apps match &ldquo;{searchTerm}&rdquo;</span>
               <span className="text-xs mt-1">Try a different search term</span>

--- a/src/components/IntegrationsComp/integrationsAppOneComp/integrationsAppOneClientComp.js
+++ b/src/components/IntegrationsComp/integrationsAppOneComp/integrationsAppOneClientComp.js
@@ -45,6 +45,7 @@ export default function IntegrationsAppOneClientComp({
     const [searchedApps, setSearchedApps] = useState([]);
     const [searchedCategories, setSearchedCategories] = useState(null);
     const [debounceValue, setDebounceValue] = useState('');
+    const [searchLoading, setSearchLoading] = useState(false);
     const [activeStep, setActiveStep] = useState(1);
 
     useEffect(() => {
@@ -88,6 +89,10 @@ export default function IntegrationsAppOneClientComp({
 
     const handleCategoriesResults = useCallback((categories) => {
         setSearchedCategories(categories);
+    }, []);
+
+    const handleLoadingChange = useCallback((loading) => {
+        setSearchLoading(loading);
     }, []);
 
     const handleDebounceValueChange = useCallback((value) => {
@@ -167,6 +172,7 @@ export default function IntegrationsAppOneClientComp({
                                     onSearchResults={handleSearchResults}
                                     onCategoriesResults={handleCategoriesResults}
                                     onDebounceValueChange={handleDebounceValueChange}
+                                    onLoadingChange={handleLoadingChange}
                                     app={appOneDetails}
                                 />
                             </div>
@@ -175,6 +181,7 @@ export default function IntegrationsAppOneClientComp({
                             pageInfo={pageInfo}
                             integrationsInfo={integrationsInfo}
                             apps={debounceValue ? searchedApps : apps}
+                            searchLoading={searchLoading}
                             appCategories={appOneDetails?.category}
                             appCount={appCount}
                             searchTerm={debounceValue}

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/TriggerOrActionCard.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/TriggerOrActionCard.js
@@ -1,18 +1,31 @@
 'use client';
 import Image from 'next/image';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ChevronDown, ChevronUp, Search } from 'lucide-react';
 import { RequestIntegrationPopupOpener } from '../IntegrationsIndexComp/IntegrationsIndexClientComp';
 
 export default function TriggerOrActionCard({ title, appDetails, placeholder, list, isOpen, onToggle, onSelect, type, resetEvent }) {
     const [search, setSearch] = useState('');
     const [selectedEvent, setSelectedEvent] = useState(null);
+    const cardRef = useRef(null);
 
     useEffect(() => {
         if (resetEvent) {
             setSelectedEvent(null);
+            setSearch('');
         }
     }, [resetEvent]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleClickOutside = (event) => {
+            if (cardRef.current && !cardRef.current.contains(event.target)) {
+                onToggle();
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen, onToggle]);
 
     const filteredList = list?.filter((item) => item?.name?.toLowerCase().includes(search.toLowerCase()));
 
@@ -26,7 +39,7 @@ export default function TriggerOrActionCard({ title, appDetails, placeholder, li
     };
 
     return (
-        <div className="flex flex-col w-full md:w-1/2 gap-2 relative">
+        <div ref={cardRef} className="flex flex-col w-full md:w-1/2 gap-2 relative">
             <h2 className="text-sm font-medium text-gray-500 text-left">{title}</h2>
 
             <div

--- a/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/integrationsAppTwoClientComp.js
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import FAQSection from '@/components/faqSection/faqSection';
 import Footer from '@/components/footer/footer';
 import ConditionalFooter from '@/components/ConditionalLayout/ConditionalFooter';
@@ -59,16 +59,6 @@ export default function IntegrationsAppTwoClientComp({
 
     const [appOneEvents, setAppOneEvents] = useState(categorizeEvents(currentAppOne?.events));
     const [appTwoEvents, setAppTwoEvents] = useState(categorizeEvents(currentAppTwo?.events));
-
-    useEffect(() => {
-        const handleClickOutside = () => {
-            if (openDropdown) {
-                setOpenDropdown(null);
-            }
-        };
-        document.addEventListener('click', handleClickOutside);
-        return () => document.removeEventListener('click', handleClickOutside);
-    }, [openDropdown]);
 
     const handleSwapApps = () => {
         const tempApp = currentAppOne;

--- a/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
+++ b/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
@@ -1,11 +1,11 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ChevronLeft, ChevronRight, Search, Headphones, CheckCircle, User, Send } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Search, Headphones, CheckCircle, User, Send, Loader2 } from 'lucide-react';
 import FAQSection from '@/components/faqSection/faqSection';
 import Footer from '@/components/footer/footer';
 import BlogGrid from '@/app/components/blog/BlogGrid';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import createURL from '@/utils/createURL';
 import McpEventComp from '../mcpEventsComp/McpEventsComp';
 import { handleRedirect } from '@/utils/handleRedirection';
@@ -31,17 +31,28 @@ export default function McpAppClientComp({
     const [searchTerm, setSearchTerm] = useState('');
     const [debounceValue, setDebounceValue] = useState('');
     const [searchedApps, setSearchedApps] = useState([]);
+    const [searchLoading, setSearchLoading] = useState(false);
+    const abortControllerRef = useRef(null);
 
     useEffect(() => {
-        const search = async () => {
-            if (!debounceValue) {
-                setSearchedApps([]);
-                return;
-            }
+        if (!debounceValue) {
+            abortControllerRef.current?.abort();
+            setSearchLoading(false);
+            setSearchedApps([]);
+            return;
+        }
 
+        abortControllerRef.current?.abort();
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        const search = async () => {
+            setSearchLoading(true);
             const searchTerm = debounceValue.toLowerCase();
 
-            const fetchedApps = await searchApps(debounceValue);
+            const fetchedApps = await searchApps(debounceValue, controller.signal);
+            if (controller.signal.aborted) return;
+            setSearchLoading(false);
             if (!fetchedApps) {
                 setSearchedApps([]);
                 return;
@@ -68,6 +79,9 @@ export default function McpAppClientComp({
         };
 
         search();
+        return () => {
+            abortControllerRef.current?.abort();
+        };
     }, [debounceValue]);
     useEffect(() => {
         const handler = setTimeout(() => {
@@ -279,6 +293,7 @@ export default function McpAppClientComp({
                                 className="grow py-2 px-3 text-black"
                                 placeholder="Search compatible apps"
                             />
+                            {searchLoading && <Loader2 className="w-4 h-4 animate-spin text-gray-400 shrink-0" aria-hidden="true" />}
                         </label>
                     </div>
 

--- a/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
+++ b/src/components/mcpComps/mcpAppComp/McpAppClientComp.js
@@ -48,7 +48,7 @@ export default function McpAppClientComp({
 
         const search = async () => {
             setSearchLoading(true);
-            const searchTerm = debounceValue.toLowerCase();
+            const searchTermLower = debounceValue.toLowerCase();
 
             const fetchedApps = await searchApps(debounceValue, controller.signal);
             if (controller.signal.aborted) return;
@@ -62,13 +62,13 @@ export default function McpAppClientComp({
                 const aName = a?.name?.toLowerCase() || '';
                 const bName = b?.name?.toLowerCase() || '';
 
-                const aStarts = aName.startsWith(searchTerm);
-                const bStarts = bName.startsWith(searchTerm);
+                const aStarts = aName.startsWith(searchTermLower);
+                const bStarts = bName.startsWith(searchTermLower);
 
                 if (aStarts !== bStarts) return aStarts ? -1 : 1;
 
-                const aContains = aName.includes(searchTerm);
-                const bContains = bName.includes(searchTerm);
+                const aContains = aName.includes(searchTermLower);
+                const bContains = bName.includes(searchTermLower);
 
                 if (aContains !== bContains) return aContains ? -1 : 1;
 

--- a/src/components/mcpComps/mcpIndexComp/McpIndexClientComp.js
+++ b/src/components/mcpComps/mcpIndexComp/McpIndexClientComp.js
@@ -33,9 +33,6 @@ export default function McpIndexClientComp({
     keyPointData,
     appCount,
 }) {
-    if (!categoryData || Object.keys(categoryData).length === 0) {
-        return <ErrorComp />;
-    }
     const [searchTerm, setSearchTerm] = useState('');
     const [debounceValue, setDebounceValue] = useState('');
     const [searchedApps, setSearchedApps] = useState([]);
@@ -45,7 +42,7 @@ export default function McpIndexClientComp({
 
     const filterPriorityCategories = (cats) => {
         if (!Array.isArray(cats)) return [];
-        return cats.sort((a, b) => {
+        return [...cats].sort((a, b) => {
             const priorityA = Number(a.priority) || Infinity;
             const priorityB = Number(b.priority) || Infinity;
             return priorityA - priorityB || a.name.localeCompare(b.name);
@@ -81,7 +78,7 @@ export default function McpIndexClientComp({
 
         const search = async () => {
             setSearchLoading(true);
-            const searchTerm = debounceValue.toLowerCase();
+            const searchTermLower = debounceValue.toLowerCase();
 
             const fetchedApps = await searchApps(debounceValue, controller.signal);
             if (controller.signal.aborted) return;
@@ -95,13 +92,13 @@ export default function McpIndexClientComp({
                 const aName = a?.name?.toLowerCase() || '';
                 const bName = b?.name?.toLowerCase() || '';
 
-                const aStarts = aName.startsWith(searchTerm);
-                const bStarts = bName.startsWith(searchTerm);
+                const aStarts = aName.startsWith(searchTermLower);
+                const bStarts = bName.startsWith(searchTermLower);
 
                 if (aStarts !== bStarts) return aStarts ? -1 : 1;
 
-                const aContains = aName.includes(searchTerm);
-                const bContains = bName.includes(searchTerm);
+                const aContains = aName.includes(searchTermLower);
+                const bContains = bName.includes(searchTermLower);
 
                 if (aContains !== bContains) return aContains ? -1 : 1;
 
@@ -133,6 +130,10 @@ export default function McpIndexClientComp({
             return url;
         }
     };
+
+    if (!categoryData || Object.keys(categoryData).length === 0) {
+        return <ErrorComp />;
+    }
 
     {
         return (

--- a/src/components/mcpComps/mcpIndexComp/McpIndexClientComp.js
+++ b/src/components/mcpComps/mcpIndexComp/McpIndexClientComp.js
@@ -1,9 +1,9 @@
 'use client';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Search, Scale, Layers, Network, Plug, Shield, Wrench, Sparkles, ChevronRight } from 'lucide-react';
+import { Search, Scale, Layers, Network, Plug, Shield, Wrench, Sparkles, ChevronRight, Loader2 } from 'lucide-react';
 import Footer from '@/components/footer/footer';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import BlogGrid from '@/app/components/blog/BlogGrid';
 import createURL from '@/utils/createURL';
 import ErrorComp from '@/components/404/404Comp';
@@ -39,7 +39,9 @@ export default function McpIndexClientComp({
     const [searchTerm, setSearchTerm] = useState('');
     const [debounceValue, setDebounceValue] = useState('');
     const [searchedApps, setSearchedApps] = useState([]);
-    const [searchedCategoies, setSearchedCategoies] = useState([]);
+    const [searchedCategoies, setSearchedCategoies] = useState();
+    const [searchLoading, setSearchLoading] = useState(false);
+    const abortControllerRef = useRef(null);
 
     const filterPriorityCategories = (cats) => {
         if (!Array.isArray(cats)) return [];
@@ -60,15 +62,30 @@ export default function McpIndexClientComp({
     }, [searchTerm]);
 
     useEffect(() => {
-        const search = async () => {
-            if (!debounceValue) {
-                setSearchedApps([]);
-                return;
-            }
+        if (!debounceValue) {
+            abortControllerRef.current?.abort();
+            setSearchLoading(false);
+            setSearchedApps([]);
+            setSearchedCategoies();
+            return;
+        }
 
+        const filteredCategories = categories?.filter((category) =>
+            category?.name?.toLowerCase()?.includes(debounceValue.toLowerCase())
+        );
+        setSearchedCategoies(filterPriorityCategories(filteredCategories));
+
+        abortControllerRef.current?.abort();
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        const search = async () => {
+            setSearchLoading(true);
             const searchTerm = debounceValue.toLowerCase();
 
-            const fetchedApps = await searchApps(debounceValue);
+            const fetchedApps = await searchApps(debounceValue, controller.signal);
+            if (controller.signal.aborted) return;
+            setSearchLoading(false);
             if (!fetchedApps) {
                 setSearchedApps([]);
                 return;
@@ -95,6 +112,9 @@ export default function McpIndexClientComp({
         };
 
         search();
+        return () => {
+            abortControllerRef.current?.abort();
+        };
     }, [debounceValue]);
 
     const showNext = apps?.length > 0 && APPERPAGE <= apps?.length;
@@ -164,6 +184,7 @@ export default function McpIndexClientComp({
                             placeholder="Search your favorite MCP Servers"
                             autoFocus
                         />
+                        {searchLoading && <Loader2 className="w-4 h-4 animate-spin text-gray-400 shrink-0" aria-hidden="true" />}
                     </label>
                     <div className="flex">
                         <div className="border custom-border lg:block hidden bg-white overflow-y-auto scrollbar-thin max-w-[252px] min-w-[252px] lg:h-[1201px] xl:h-[901px] h-[78.125vw]">

--- a/src/hooks/useTemplateFilters.js
+++ b/src/hooks/useTemplateFilters.js
@@ -12,66 +12,42 @@ export const useTemplateFilters = (templates = []) => {
     const [customIndustry, setCustomIndustry] = useState('');
 
     const filteredTemplates = useMemo(() => {
-        let filtered = [...templates];
-        let filteredChanged = false;
+        let filtered = templates;
 
         // Filter by categories (industries and departments included)
         if (selectedCategories.length > 0) {
-            filteredChanged = true;
             filtered = filtered.filter((template) => {
                 return template.category && template.category.some((cat) => selectedCategories.includes(cat));
             });
-
-            if (customIndustry === '' && filtered.length === 0) {
-                filtered = [...templates];
-            }
         }
 
-        // Filter by apps
+        // Filter by apps — narrows whatever the category filter above already produced
         if (selectedApps.length > 0) {
-
-            let filterFunction = (template) => {
+            const appMatches = (template, slug) => {
+                if (slug === 'webhook') return template.triggerType === 'webhook';
+                if (slug === 'cron') return template.triggerType === 'cron';
                 const pluginSlugs = (template.pluginData || []).map((p) => p.pluginslugname);
+                return pluginSlugs.includes(slug);
+            };
 
-                const appMatches = (slug) => {
-                    if (slug === 'webhook') return template.triggerType === 'webhook';
-                    if (slug === 'cron') return template.triggerType === 'cron';
-                    return pluginSlugs.includes(slug);
-                };
-
-                return requireAllApps
-                    ? selectedApps.every(appMatches) // AND logic
-                    : selectedApps.some(appMatches);  // OR logic (default)
-            }
-            if (filteredChanged) {
-                const selectedAppFiltered = templates.filter(filterFunction)
-                filtered = [...filtered, ...selectedAppFiltered]
-            } else {
-                filtered = filtered.filter(filterFunction);
-            }
-            filteredChanged = true;
+            filtered = filtered.filter((template) =>
+                requireAllApps
+                    ? selectedApps.every((slug) => appMatches(template, slug)) // AND logic
+                    : selectedApps.some((slug) => appMatches(template, slug)) // OR logic (default)
+            );
         }
 
-        // Filter by search term
+        // Filter by search term — narrows whatever category/app filters already produced
         if (searchTerm.trim()) {
-            const filterFunction = (template) =>
-                template.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                template.metadata?.description?.toLowerCase().includes(searchTerm.toLowerCase())
-            if (filteredChanged) {
-                const searchTermFiltered = templates.filter(filterFunction)
-                filtered = [...filtered, ...searchTermFiltered]
-            } else {
-                filtered = filtered.filter(filterFunction);
-            }
-            filteredChanged = true;
+            const term = searchTerm.toLowerCase();
+            filtered = filtered.filter(
+                (template) =>
+                    template.title?.toLowerCase().includes(term) ||
+                    template.metadata?.description?.toLowerCase().includes(term)
+            );
         }
 
-        // Deduplicate templates when multiple filter branches merge overlapping matches
-        filtered = Array.from(new Map(filtered.map((template) => [template.id, template])).values());
-
-
-        // Clean up match scores
-        return filtered.map(({ matchScore, ...rest }) => rest);
+        return filtered;
     }, [templates, searchTerm, selectedCategories, selectedApps, requireAllApps]);
 
     // Memoized sorted templates

--- a/src/utils/searchApps.js
+++ b/src/utils/searchApps.js
@@ -1,16 +1,17 @@
 import { sendErrorMessage } from './SendErrorMessage';
 
-export default async function searchApps(query) {
-    const url = `${process.env.NEXT_PUBLIC_INTEGRATION_URL}plugins/search?key=${query}&integrationOnly=true`;
+export default async function searchApps(query, signal) {
+    const url = `${process.env.NEXT_PUBLIC_INTEGRATION_URL}plugins/search?key=${encodeURIComponent(query)}&integrationOnly=true`;
 
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, { signal });
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
         const data = await response.json();
         return data.data;
     } catch (error) {
+        if (error?.name === 'AbortError') return;
         sendErrorMessage({ error, source: url });
     }
 }


### PR DESCRIPTION
## Summary
- Debounce the home, Integrations, and MCP search boxes (400ms) instead of firing a request on every keystroke.
- Cancel stale in-flight search requests via AbortController so a slow, older response can no longer overwrite newer results.
- Show a loading spinner in the search box while a request is in flight.
- Home search now matches app names anywhere in the string, not just the start.
- Simplify the template filter logic in `useTemplateFilters` to narrow results sequentially instead of merging separate filter branches and deduping afterward.
- URL-encode the search query in `searchApps`.

This PR is scoped specifically to the search component and will be the base for further search-related work.

## Test plan
- [ ] Type quickly in the home page search box — confirm no flicker/stale results and a spinner shows while loading
- [ ] Same check on the Integrations page search and MCP page search
- [ ] Confirm searching "ram" on home matches "Telegram" (substring match, not just prefix)
- [ ] Confirm template filtering by category/app/search term still works correctly with no duplicate results