### PR TITLE
Fix footer icon circles and alignment

### DIFF
--- a/src/components/footer/ExploreWithAIButton.js
+++ b/src/components/footer/ExploreWithAIButton.js
@@ -72,20 +72,20 @@ export default function ExploreWithAIButton() {
     };
 
     return (
-        <div className="flex items-center gap-2 justify-between w-full">
-            <p className="text-xs font-semibold text-gray-700 flex items-center gap-2">Explore with AI</p>
-            <div className="flex gap-2 items-center md:gap-3">
+        <div className="flex items-center gap-2 justify-between w-full flex-wrap">
+            <p className="text-xs font-semibold text-gray-700 flex items-center gap-2 whitespace-nowrap">Explore with AI</p>
+            <div className="flex gap-1 items-center md:gap-2">
                 {AI_PROVIDERS.map((provider) => {
                     const IconComponent = provider.icon;
                     return (
-                        <div key={provider.id} className="group relative flex">
+                        <div key={provider.id} className="group relative flex shrink-0">
                             <button
                                 onClick={() => handleProviderClick(provider.id)}
-                                className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-600 transition-all duration-200 hover:border-accent hover:text-accent hover:bg-accent/5"
+                                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-600 transition-all duration-200 hover:border-accent hover:text-accent hover:bg-accent/5"
                                 title={provider.name}
                                 aria-label={provider.name}
                             >
-                                <IconComponent className="w-4 h-4" />
+                                <IconComponent className="w-3.5 h-3.5" />
                             </button>
                             <span className="pointer-events-none absolute left-1/2 top-full mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-sm transition-opacity duration-200 group-hover:opacity-100">
                                 {provider.name}

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -97,47 +97,47 @@ export default function Footer({ footerData, borderClass, isBlack = false }) {
                                 />
                             </div>
 
-                            <div className="flex gap-2 justify-center items-center md:gap-6">
+                            <div className="flex flex-wrap gap-2 justify-center items-center md:gap-4">
                                 <Link
                                     href={`https://www.instagram.com/viasocket/`}
                                     target="_blank"
                                     aria-label="instagram"
-                                    className="flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 hover:border-accent transition-colors"
+                                    className="flex shrink-0 items-center justify-center w-8 h-8 rounded-full border border-gray-300 hover:border-accent transition-colors"
                                 >
-                                    <Instagram className="w-4 h-4" />
+                                    <Instagram className="w-3.5 h-3.5" />
                                 </Link>
                                 <Link
                                     href={`https://www.linkedin.com/company/viasocket-walkover/`}
                                     target="_blank"
                                     aria-label="facebook"
-                                    className="flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 hover:border-accent transition-colors"
+                                    className="flex shrink-0 items-center justify-center w-8 h-8 rounded-full border border-gray-300 hover:border-accent transition-colors"
                                 >
-                                    <Linkedin className="w-4 h-4" />
+                                    <Linkedin className="w-3.5 h-3.5" />
                                 </Link>
 
                                 <Link
                                     href={`https://x.com/viasocket`}
                                     target="_blank"
-                                    className="flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 hover:border-accent transition-colors"
+                                    className="flex shrink-0 items-center justify-center w-8 h-8 rounded-full border border-gray-300 hover:border-accent transition-colors"
                                     aria-label="twitter"
                                 >
-                                    <Twitter className="w-4 h-4" />
+                                    <Twitter className="w-3.5 h-3.5" />
                                 </Link>
                                 <Link
                                     href={`https://www.youtube.com/@viasocket`}
                                     target="_blank"
-                                    className="flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 hover:border-accent transition-colors"
+                                    className="flex shrink-0 items-center justify-center w-8 h-8 rounded-full border border-gray-300 hover:border-accent transition-colors"
                                     aria-label="youtube"
                                 >
-                                    <YouTubeIcon className="w-4 h-4" />
+                                    <YouTubeIcon className="w-3.5 h-3.5" />
                                 </Link>
                                 <Link
                                     href={`https://discord.com/invite/wqsSsMAkkz`}
                                     target="_blank"
                                     aria-label="discord"
-                                    className="flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 hover:border-accent transition-colors"
+                                    className="flex shrink-0 items-center justify-center w-8 h-8 rounded-full border border-gray-300 hover:border-accent transition-colors"
                                 >
-                                    <MessageCircle className="w-4 h-4" />
+                                    <MessageCircle className="w-3.5 h-3.5" />
                                 </Link>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Fix social and AI icon buttons distorting into ovals under flexbox squeeze (missing `shrink-0`), now hold a fixed circular shape and wrap onto a new line instead when space is tight.
- Keep the "Explore with AI" label on one line (`whitespace-nowrap`).
- Resize both the AI provider icons and social icons to a matching, slightly smaller size with tighter spacing.

## Test plan
- [x] Verified circles stay perfectly round at 1512px, 1440px, 1112px, and 390px (mobile) viewport widths
- [x] Verified "Explore with AI" label stays on one line at common desktop widths
- [x] Verified social icon row (Instagram/LinkedIn/Twitter/YouTube/Discord) still renders on one line and matches new icon size

🤖 Generated with [Claude Code](https://claude.com/claude-code)