### PR TITLE
Fix integration request popup logic and add appName to payload

### DIFF
--- a/src/components/IntegrationsComp/IntegrationsBetaComp/integrationsRequestComp.js
+++ b/src/components/IntegrationsComp/IntegrationsBetaComp/integrationsRequestComp.js
@@ -88,6 +88,7 @@ export function RequestPlugin({ appInfo, secondAppInfo = null, type, onClose }) 
         const { plug, ...cleanedPayload } = formDataToSend;
         cleanedPayload.userNeed = `New ${type || 'App'}`;
         cleanedPayload.category = appInfo?.category?.join(', ');
+        cleanedPayload.appName = formData.plug?.name || appInfo?.name || '';
 
         try {
             setIsLoading(true);
@@ -163,7 +164,7 @@ export function RequestPlugin({ appInfo, secondAppInfo = null, type, onClose }) 
             )}
 
             {!showSuccessPopup && (
-                <div className="modal-box !overflow-hidden !p-4 max-h-[90vh] shadow-2xl">
+                <div className="modal-box !overflow-auto !p-4 max-h-[90vh] shadow-2xl">
                     <div className="flex flex-col gap-4 overflow-hidden">
                         <div className="flex flex-col gap-2">
                             <div className="flex gap-3 items-center">

--- a/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
+++ b/src/components/IntegrationsComp/IntegrationsIndexComp/IntegrationsIndexClientComp.js
@@ -389,6 +389,7 @@ export function RequestIntegrationPopupOpener({
     const TYPE_KEY = 'requestType';
     const isOpen = searchParams?.get(QUERY_KEY) === 'true';
     const requestType = searchParams?.get(TYPE_KEY);
+    const shouldOpen = isOpen && ((!type && !requestType) || type === requestType);
 
     const updateQueryParam = (open) => {
         const params = new URLSearchParams(searchParams?.toString() || '');
@@ -499,7 +500,7 @@ export function RequestIntegrationPopupOpener({
     return (
         <>
             {getUi()}
-            {isOpen && (
+            {shouldOpen && (
                 <IntegrationsRequestComp
                     appInfo={appInfo}
                     secondAppInfo={secondAppInfo}

--- a/src/components/IntegrationsComp/integrationsAppComp/integrationsAppComp.js
+++ b/src/components/IntegrationsComp/integrationsAppComp/integrationsAppComp.js
@@ -13,6 +13,7 @@ export default function IntegrationsAppComp({
     appCount,
     searchTerm,
     searchedCategories,
+    appOneDetails,
 }) {
 
     return (
@@ -112,6 +113,7 @@ export default function IntegrationsAppComp({
                                         <RequestIntegrationPopupOpener
                                             showType="searchView"
                                             className="md:border-t-0 md:border-l-0"
+                                            appInfo={appOneDetails}
                                         />
                                     </div>
                                 )

--- a/src/components/IntegrationsComp/integrationsAppOneComp/integrationsAppOneClientComp.js
+++ b/src/components/IntegrationsComp/integrationsAppOneComp/integrationsAppOneClientComp.js
@@ -179,6 +179,7 @@ export default function IntegrationsAppOneClientComp({
                             appCount={appCount}
                             searchTerm={debounceValue}
                             searchedCategories={searchedCategories}
+                            appOneDetails={appOneDetails}
                         />
                     </div>
                 )}


### PR DESCRIPTION
- Add appName field to cleanedPayload using formData.plug?.name, appInfo?.name, or empty string
- Change modal-box overflow from !overflow-hidden to !overflow-auto for better scrollability
- Add shouldOpen condition to only show popup when type matches requestType or both are undefined
- Pass appOneDetails prop through IntegrationsAppComp to RequestIntegrationPopupOpener in search view || 1