### PR TITLE
Highlight selected combo card and update template section heading

### DIFF
--- a/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
+++ b/src/components/IntegrationsComp/integrationsAppTwoComp/PopularFlows.js
@@ -118,7 +118,9 @@ export default function PopularFlows({
                         href={selectedCombo.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="bg-white rounded-xl border custom-border p-6 flex flex-col gap-4 hover:shadow-md transition-shadow group"
+                        className={`bg-white rounded-xl border p-6 flex flex-col gap-4 hover:shadow-md transition-shadow group ${
+                            highlightSelectedCombo ? 'border-accent border-2' : 'custom-border'
+                        }`}
                     >
                         <div className="flex items-center gap-2">
                             <div className="w-9 h-9 border custom-border overflow-hidden bg-white flex items-center justify-center shrink-0">

--- a/src/components/indexComps/indexTemplateComp.js
+++ b/src/components/indexComps/indexTemplateComp.js
@@ -74,7 +74,7 @@ const IndexTemplateComp = ({ categories, templates }) => {
     return (
         <div className="cont gap-8 container relative mt-12 py-8">
             <div className="flex flex-col gap-1 items-center justify-center">
-                <h2 className="h2">Your team's workflows, already built.</h2>
+                <h2 className="h2">From generating Leads to Raising Fund</h2>
                 <p>Browse templates for Finance, Marketing, Support, HR and more. One click to deploy.</p>
             </div>
 


### PR DESCRIPTION
## Summary
- Two-app integration page: when a user picks both a trigger and an action, the matching flow card now shows a brand-accent (`#A8200D`) border alongside the existing "Use this flow" highlight, instead of a plain gray border.
- Homepage template section heading changed from "Your team's workflows, already built." to "From generating Leads to Raising Fund".

## Test plan
- [ ] Visit `/integrations/<app1>/<app2>` (e.g. `/integrations/slack/gmail`), select a trigger and action, confirm the matching card gets a red/accent border and "Use this flow" text for a few seconds
- [ ] Visit homepage, confirm the templates section heading reads "From generating Leads to Raising Fund"