### PR TITLE
Move prompt storage to utmData cookie and set variant cookie domain t…

### DIFF
--- a/src/app/components/home/HeroSectionB.js
+++ b/src/app/components/home/HeroSectionB.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Sparkles, ArrowRight, User, AlertTriangle, CalendarDays } from 'lucide-react';
 import { handleRedirect } from '@/utils/handleRedirection';
+import { getCookie, setCookie } from '@/utils/handleUtmSource';
 
 const SVG_BASE =
     'absolute inset-0 w-full h-full transition-[opacity,transform] duration-[400ms] ease-[cubic-bezier(0.4,0,0.2,1)]';
@@ -26,7 +27,9 @@ export default function HeroSectionB({ hasToken }) {
         // Carry the described automation forward via a cookie + localStorage (not the URL)
         const value = prompt.trim();
         if (typeof document !== 'undefined' && value) {
-            document.cookie = `prompt=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24}; samesite=lax`;
+            const utmData = JSON.parse(getCookie('utmData') || '{}');
+            utmData.prompt = value;
+            setCookie('utmData', JSON.stringify(utmData), 1);
             try {
                 window.localStorage.setItem('prompt', value);
             } catch {}

--- a/src/components/AbTestInit.js
+++ b/src/components/AbTestInit.js
@@ -1,18 +1,6 @@
 'use client';
 import { useEffect } from 'react';
-
-const getCookie = (name) => {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-};
-
-const setCookie = (name, value, days) => {
-    const date = new Date();
-    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-    const expires = `expires=${date.toUTCString()}`;
-    document.cookie = `${name}=${value};${expires};path=/`;
-};
+import { getCookie, setCookie } from '@/utils/handleUtmSource';
 
 export default function AbTestInit({ variant }) {
     useEffect(() => {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -24,10 +24,13 @@ export async function middleware(request) {
     const existingVariant = request.cookies.get(VARIANT_COOKIE)?.value;
     if (!existingVariant || !VARIANTS.includes(existingVariant)) {
         const variant = VARIANTS[Math.floor(Math.random() * VARIANTS.length)];
+        const hostname = request.nextUrl.hostname;
+        const isViasocket = hostname === 'viasocket.com' || hostname.endsWith('.viasocket.com');
         response.cookies.set(VARIANT_COOKIE, variant, {
             maxAge: VARIANT_MAX_AGE,
             path: '/',
             sameSite: 'lax',
+            domain: isViasocket ? '.viasocket.com' : undefined,
         });
     }
 


### PR DESCRIPTION
…o .viasocket.com

- Store user prompt in utmData cookie instead of separate prompt cookie
- Parse existing utmData, add prompt field, and save back to utmData cookie
- Extract getCookie and setCookie utilities to shared handleUtmSource module
- Remove duplicate cookie utility functions from AbTestInit component
- Set variant cookie domain to .viasocket.com when hostname matches viasocket.com or subdomains || 1