### PR TITLE
Set variant cookie domain to root domain instead of hardcoding .viaso…

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -24,13 +24,16 @@ export async function middleware(request) {
     const existingVariant = request.cookies.get(VARIANT_COOKIE)?.value;
     if (!existingVariant || !VARIANTS.includes(existingVariant)) {
         const variant = VARIANTS[Math.floor(Math.random() * VARIANTS.length)];
-        const hostname = request.nextUrl.hostname;
-        const isViasocket = hostname === 'viasocket.com' || hostname.endsWith('.viasocket.com');
+        const host = request.headers.get('host') || '';
+        const hostname = host.split(':')[0];
+        const parts = hostname.split('.');
+        const rootDomain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
+        const domain = hostname ? `.${rootDomain}` : undefined;
         response.cookies.set(VARIANT_COOKIE, variant, {
             maxAge: VARIANT_MAX_AGE,
             path: '/',
             sameSite: 'lax',
-            domain: isViasocket ? '.viasocket.com' : undefined,
+            domain,
         });
     }
 


### PR DESCRIPTION
…cket.com

- Extract hostname from Host header and parse to get root domain
- Calculate root domain by taking last two parts of hostname (e.g., example.com from sub.example.com)
- Set variant cookie domain to .{rootDomain} for all domains instead of checking for viasocket.com specifically
- Remove hardcoded viasocket.com domain check and isViasocket variable ||  1