### PR TITLE
Prevent variant cookie overwrite if valid variant already exists

### DIFF
--- a/src/utils/handleUtmSource.js
+++ b/src/utils/handleUtmSource.js
@@ -25,7 +25,8 @@ export const setCookie = (name, value, days) => {
 export const setVariantCookie = (variant) => {
     const VARIANTS = ['A', 'B', 'C'];
     if (!VARIANTS.includes(variant)) return;
-    if (getCookie('variant') === variant) return;
+    const existing = getCookie('variant');
+    if (existing && VARIANTS.includes(existing)) return;
     setCookie('variant', variant, 30);
 };
 


### PR DESCRIPTION
- Check if existing variant cookie value is a valid variant (A, B, or C)
- Only skip setting new variant if existing value is valid, not just if it matches
- Store existing cookie value in variable for validation before comparison || 4