### PR TITLE
Clear templateIds when switching to apps tab and clear slots when swi…

### DIFF
--- a/src/app/components/integrations-script/SetupBuilder.js
+++ b/src/app/components/integrations-script/SetupBuilder.js
@@ -28,6 +28,16 @@ export default function SetupBuilder({ initialApps = [] }) {
         // If templateId is in URL, default to template tab
         return searchParams?.get('templateId') ? 'template' : 'apps';
     });
+
+    const handleTabChange = (tab) => {
+        setPickerTab(tab);
+        // Clear the other selection when switching tabs
+        if (tab === 'apps') {
+            setTemplateIds([]);
+        } else if (tab === 'template') {
+            setSlots(Array(TOTAL_SLOTS).fill(null));
+        }
+    };
     const debounceRef = useRef(null);
     const preselectDoneRef = useRef(false);
     const [canSyncParams, setCanSyncParams] = useState(!preselectSlugs.length);
@@ -155,22 +165,28 @@ export default function SetupBuilder({ initialApps = [] }) {
     const features = slots.slice(1).filter(Boolean);
 
     const scriptCode = useMemo(() => {
-        const primarySlug = primary?.appslugname || 'your_app_slug';
-        const lines = [`<script`, `  primaryApp="${primarySlug}"`];
-        features.forEach((app, i) => {
-            lines.push(`  appName${i + 1}="${app.appslugname}"`);
-        });
+        const lines = [`<script`];
+        
+        if (pickerTab === 'apps') {
+            const primarySlug = primary?.appslugname || 'your_app_slug';
+            lines.push(`  primaryApp="${primarySlug}"`);
+            features.forEach((app, i) => {
+                lines.push(`  appName${i + 1}="${app.appslugname}"`);
+            });
+        } else if (pickerTab === 'template' && templateIds.length) {
+            lines.push(`  templateIds="${templateIds.join(',')}"`);
+        }
+        
         if (refCode.trim()) lines.push(`  ref="${refCode.trim()}"`);
-        if (templateIds.length) lines.push(`  templateIds="${templateIds.join(',')}"`);
         if (domain.trim()) lines.push(`  domain="${domain.trim()}"`);
         lines.push(`  id="viasocket_integrations"`);
         lines.push(`  crossorigin="anonymous"`);
         lines.push(`  src="https://integrations.viasocket.com/integrations.js">`);
         lines.push(`</script>`);
         return lines.join('\n');
-    }, [primary, features, refCode, templateIds, domain]);
+    }, [primary, features, refCode, templateIds, domain, pickerTab]);
 
-    const canCopy = !!primary;
+    const canCopy = pickerTab === 'apps' ? !!primary : templateIds.length > 0;
 
     const handleCopy = async () => {
         if (!canCopy) return;
@@ -220,7 +236,7 @@ export default function SetupBuilder({ initialApps = [] }) {
                             domain={domain}
                             setDomain={setDomain}
                             activeTab={pickerTab}
-                            setActiveTab={setPickerTab}
+                            setActiveTab={handleTabChange}
                         />
                     </div>
                     <div className="w-full min-w-0">

--- a/src/components/IntegrationsComp/integrationsAppOneComp/realWorldUseCase.js
+++ b/src/components/IntegrationsComp/integrationsAppOneComp/realWorldUseCase.js
@@ -49,6 +49,15 @@ const INTEGRATION_APPS = [
 
 const DEFAULT_ICON = 'https://placehold.co/120x120/0F9D58/white?text=GS';
 
+const HARDCODED_USE_CASES = [
+    'Start a workflow in your other tools whenever something new happens in [app_name].',
+    'Update records in [app_name] automatically when data changes in the apps your team already uses.',
+    'Log [app_name] activity into a spreadsheet or database so reporting stays current without manual entry.',
+    'Alert the right teammate or channel when an important [app_name] event needs a response.',
+    'Add AI steps that summarize, classify, or draft text from your [app_name] data mid-workflow.',
+    'Run [app_name] workflows on a daily or weekly schedule to keep records and reports in sync.',
+];
+
 const hexToRgba = (hex, alpha = 1) => {
     const h = (hex || '').replace('#', '');
     const full =
@@ -123,10 +132,12 @@ const RealWorldUseCase = ({ appOneDetails, combosData, appCount, appData }) => {
             return raw.map(getUseCaseText).filter(Boolean);
         }
         const fallback = appData?.useCasesCardsData || [];
-        return Array.isArray(fallback)
-            ? fallback.map((item) => (typeof item === 'string' ? item : item?.title || '')).filter(Boolean)
-            : [];
-    }, [appData?.useCasesNewData, appData?.useCasesCardsData]);
+        if (Array.isArray(fallback) && fallback.length > 0) {
+            return fallback.map((item) => (typeof item === 'string' ? item : item?.title || '')).filter(Boolean);
+        }
+        // Final fallback to hardcoded use cases with app name replacement
+        return HARDCODED_USE_CASES.map(useCase => useCase.replace(/\[app_name\]/g, appName));
+    }, [appData?.useCasesNewData, appData?.useCasesCardsData, appName]);
 
     // Get dynamic app icons from combosData
     const dynamicApps = useMemo(() => {


### PR DESCRIPTION
…tching to template tab

- Add handleTabChange function to clear opposite selection when switching tabs
- Update scriptCode generation to conditionally include primaryApp/appName or templateIds based on active tab
- Modify canCopy logic to check templateIds.length when on template tab
- Replace direct setPickerTab calls with handleTabChange in SetupBuilder
- Add HARDCODED_USE_CASES array as final fallback with [app_name] placeholder || 1